### PR TITLE
add german translations for FoF/polls

### DIFF
--- a/resources/locale/de.yml
+++ b/resources/locale/de.yml
@@ -1,0 +1,44 @@
+fof-polls:
+  admin:
+    permissions:
+      moderate: Umfragen bearbeiten & entfernen
+      self_edit: Usern erlauben eigene Umfragen zu bearbeiten
+      start: Umfrage starten
+      vote: Umfrage abstimmen
+
+  forum:
+    days_remaining: Umfrage endet in {time}.
+    no_permission: Du hast keine Berechtigung abzustimmen
+    poll_ended: Diese Umfrage ist zu Ende.
+    public_poll: Abstimmungsergebnis
+
+    composer_discussion:
+      add_poll: Umfrage hinzufügen
+      edit_poll: Umfrage bearbeiten
+
+    modal:
+      add_title: Umfrage hinzufügen
+      add_option_label: Auswahl hinzufügen
+      date_placeholder: Enddatum der Umfrage (Optional)
+      edit_title: Umfrage bearbeiten
+      include_question: Du musst eine Frage stellen
+      max: Du kannst nicht mehr als 10 Antworten erstellen
+      min: Du musst mindestens zwei Antworten erstellen
+      no_voters: Keine Votes
+      option_placeholder: Antworten
+      options_label: Antworten
+      public_poll_label: Alle dürfen sehen, wer abgestimmt hat
+      question_placeholder: Frage
+      submit: Abstimmen
+
+    moderation:
+      delete: Umfrage entfernen
+      delete_confirm: Bist du sicher, dass du die Umfrage entfernen willst?
+      edit: Umfrage bearbeiten
+
+    tooltip:
+      badge: Umfrage
+      votes: "Eine Abstimmung|{count} Abstimmungen"
+
+    votes_modal:
+      title: Wähler


### PR DESCRIPTION
Hi FoF :)

I have added translations for the German language to the best of my knowledge and belief.

It is not always a 1:1 translation, but it reflects the natural German language and terminology used in other forums.

I would be delighted if you would include this addition.

A screen of a post with a poll:
![grafik](https://user-images.githubusercontent.com/6892447/73395734-62728000-42e0-11ea-95cd-ed3296997c14.png)

A screen of the voters:
![grafik](https://user-images.githubusercontent.com/6892447/73395798-7cac5e00-42e0-11ea-82c5-5f32881c8fa3.png)

A screen of the poll creation dialog:
![grafik](https://user-images.githubusercontent.com/6892447/73395903-9ea5e080-42e0-11ea-950a-9515a709a4c4.png)


Thank you