### PR TITLE
Use vote_count attributes instead of loading all votes

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/extend.php
+++ b/extend.php
@@ -60,11 +60,17 @@ return [
         ->addInclude('poll'),
 
     (new Extend\ApiController(Controller\ShowDiscussionController::class))
-        ->addInclude(['poll', 'poll.options', 'poll.votes', 'poll.votes.user', 'poll.votes.option']),
+        ->addInclude(['poll', 'poll.options', 'poll.myVotes', 'poll.myVotes.option'])
+        ->addOptionalInclude(['poll.votes', 'poll.votes.user', 'poll.votes.option']),
 
     (new Extend\ApiController(Controller\CreateDiscussionController::class))
-        ->addInclude(['poll', 'poll.options', 'poll.votes', 'poll.votes.user', 'poll.votes.option']),
+        ->addInclude(['poll', 'poll.options', 'poll.myVotes', 'poll.myVotes.option'])
+        ->addOptionalInclude(['poll.votes', 'poll.votes.user', 'poll.votes.option']),
 
     (new Extend\ApiController(Controller\UpdateDiscussionController::class))
-        ->addInclude(['poll', 'poll.options', 'poll.votes', 'poll.votes.user', 'poll.votes.option']),
+        ->addInclude(['poll', 'poll.options', 'poll.myVotes', 'poll.myVotes.option'])
+        ->addOptionalInclude(['poll.votes', 'poll.votes.user', 'poll.votes.option']),
+
+    (new Extend\Console())
+        ->command(Console\RefreshVoteCountCommand::class),
 ];

--- a/js/src/forum/models/Poll.js
+++ b/js/src/forum/models/Poll.js
@@ -6,9 +6,11 @@ export default class Poll extends mixin(Model, {
     hasEnded: Model.attribute('hasEnded'),
     endDate: Model.attribute('endDate'),
     publicPoll: Model.attribute('publicPoll'),
+    voteCount: Model.attribute('voteCount'),
 
     options: Model.hasMany('options'),
     votes: Model.hasMany('votes'),
+    myVotes: Model.hasMany('myVotes'),
 }) {
     apiEndpoint() {
         return `/fof/polls${this.exists ? `/${this.data.id}` : ''}`;

--- a/js/src/forum/models/PollOption.js
+++ b/js/src/forum/models/PollOption.js
@@ -3,6 +3,7 @@ import mixin from 'flarum/utils/mixin';
 
 export default class PollOption extends mixin(Model, {
     answer: Model.attribute('answer'),
+    voteCount: Model.attribute('voteCount'),
 
     poll: Model.hasOne('polls'),
     votes: Model.hasMany('votes'),

--- a/migrations/2019_07_01_000000_add_polls_table.php
+++ b/migrations/2019_07_01_000000_add_polls_table.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/migrations/2019_07_01_000001_add_poll_options_table.php
+++ b/migrations/2019_07_01_000001_add_poll_options_table.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/migrations/2019_07_01_000002_add_poll_votes_table.php
+++ b/migrations/2019_07_01_000002_add_poll_votes_table.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/migrations/2021_04_06_000000_alter_options_add_vote_count.php
+++ b/migrations/2021_04_06_000000_alter_options_add_vote_count.php
@@ -1,0 +1,7 @@
+<?php
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('poll_options', [
+    'vote_count' => ['integer', 'unsigned' => true, 'default' => 0],
+]);

--- a/migrations/2021_04_06_000000_alter_options_add_vote_count.php
+++ b/migrations/2021_04_06_000000_alter_options_add_vote_count.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Flarum\Database\Migration;
 
 return Migration::addColumns('poll_options', [

--- a/migrations/2021_04_06_000001_alter_polls_add_vote_count.php
+++ b/migrations/2021_04_06_000001_alter_polls_add_vote_count.php
@@ -1,0 +1,7 @@
+<?php
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('polls', [
+    'vote_count' => ['integer', 'unsigned' => true, 'default' => 0],
+]);

--- a/migrations/2021_04_06_000001_alter_polls_add_vote_count.php
+++ b/migrations/2021_04_06_000001_alter_polls_add_vote_count.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Flarum\Database\Migration;
 
 return Migration::addColumns('polls', [

--- a/src/Api/Controllers/DeletePollController.php
+++ b/src/Api/Controllers/DeletePollController.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Api/Controllers/EditPollController.php
+++ b/src/Api/Controllers/EditPollController.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Api/Controllers/VotePollController.php
+++ b/src/Api/Controllers/VotePollController.php
@@ -26,7 +26,9 @@ class VotePollController extends AbstractShowController
      */
     public $serializer = PollSerializer::class;
 
-    public $include = ['options', 'votes', 'votes.option', 'votes.user'];
+    public $include = ['options', 'myVotes', 'myVotes.option'];
+
+    public $optionalInclude = ['votes', 'votes.option', 'votes.user'];
 
     /**
      * @var Dispatcher

--- a/src/Api/Controllers/VotePollController.php
+++ b/src/Api/Controllers/VotePollController.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -32,7 +32,7 @@ class PollOptionSerializer extends AbstractSerializer
     {
         return [
             'answer'    => $option->answer,
-            'voteCount' => (int)$option->vote_count,
+            'voteCount' => (int) $option->vote_count,
             'createdAt' => $this->formatDate($option->created_at),
             'updatedAt' => $this->formatDate($option->updated_at),
         ];

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -32,6 +32,7 @@ class PollOptionSerializer extends AbstractSerializer
     {
         return [
             'answer'    => $option->answer,
+            'voteCount' => (int)$option->vote_count,
             'createdAt' => $this->formatDate($option->created_at),
             'updatedAt' => $this->formatDate($option->updated_at),
         ];

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -34,6 +34,7 @@ class PollSerializer extends AbstractSerializer
             'question'    => $poll->question,
             'hasEnded'    => $poll->hasEnded(),
             'publicPoll'  => (bool) $poll->public_poll,
+            'voteCount'   => (int) $poll->vote_count,
             'endDate'     => $this->formatDate($poll->end_date),
             'createdAt'   => $this->formatDate($poll->created_at),
             'updatedAt'   => $this->formatDate($poll->updated_at),
@@ -50,6 +51,19 @@ class PollSerializer extends AbstractSerializer
 
     public function votes($model)
     {
+        return $this->hasMany(
+            $model,
+            PollVoteSerializer::class
+        );
+    }
+
+    public function myVotes($model)
+    {
+        Poll::setStateUser($this->actor);
+
+        // When called inside ShowDiscussionController, Flarum has already pre-loaded our relationship incorrectly
+        $model->unsetRelation('myVotes');
+
         return $this->hasMany(
             $model,
             PollVoteSerializer::class

--- a/src/Api/Serializers/PollVoteSerializer.php
+++ b/src/Api/Serializers/PollVoteSerializer.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Commands/DeletePoll.php
+++ b/src/Commands/DeletePoll.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Commands/DeletePollHandler.php
+++ b/src/Commands/DeletePollHandler.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Commands/EditPoll.php
+++ b/src/Commands/EditPoll.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Commands/EditPollHandler.php
+++ b/src/Commands/EditPollHandler.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Commands/VotePoll.php
+++ b/src/Commands/VotePoll.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Commands/VotePollHandler.php
+++ b/src/Commands/VotePollHandler.php
@@ -34,7 +34,7 @@ class VotePollHandler
     private $settings;
 
     /**
-     * @param Dispatcher $events
+     * @param Dispatcher                  $events
      * @param SettingsRepositoryInterface $settings
      */
     public function __construct(Dispatcher $events, SettingsRepositoryInterface $settings)

--- a/src/Commands/VotePollHandler.php
+++ b/src/Commands/VotePollHandler.php
@@ -15,10 +15,11 @@ use Flarum\User\Exception\PermissionDeniedException;
 use Flarum\User\User;
 use FoF\Polls\Events\PollWasVoted;
 use FoF\Polls\Poll;
+use FoF\Polls\PollOption;
 use FoF\Polls\PollVote;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
-use Pusher\Pusher;
+use Pusher;
 
 class VotePollHandler
 {
@@ -38,9 +39,12 @@ class VotePollHandler
     public function handle(VotePoll $command)
     {
         /**
-         * @var User
+         * @var $actor User
          */
         $actor = $command->actor;
+        /**
+         * @var $poll Poll
+         */
         $poll = Poll::findOrFail($command->pollId);
         $data = $command->data;
 
@@ -53,29 +57,59 @@ class VotePollHandler
         }
 
         /**
-         * @var PollVote|null
+         * @var $vote PollVote|null
          */
         $vote = $poll->votes()->where('user_id', $actor->id)->first();
 
+        $previousOption = null;
+
         if ($optionId === null && $vote !== null) {
+            $previousOption = $vote->option;
+
             $vote->delete();
+            $vote = null;
         } elseif ($optionId !== null) {
-            $vote = $poll->votes()->updateOrCreate([
-                'user_id' => $actor->id,
-            ], [
-                'option_id' => $optionId,
-            ]);
+            if ($vote) {
+                $previousOption = $vote->option;
+
+                $vote->option_id = $optionId;
+                $vote->save();
+            } else {
+                $vote = $poll->votes()->create([
+                    'user_id' => $actor->id,
+                    'option_id' => $optionId,
+                ]);
+            }
+
+            // Forget the relation in case is was loaded for $previousOption
+            $vote->unsetRelation('option');
+
+            $vote->option->refreshVoteCount()->save();
 
             app('events')->dispatch(new PollWasVoted($actor, $poll, $vote, $vote !== null));
 
             $this->pushNewVote($vote);
         }
 
+        $poll->refreshVoteCount()->save();
+
+        if ($previousOption) {
+            $previousOption->refreshVoteCount()->save();
+
+            $this->pushUpdatedOption($previousOption);
+        }
+
+        if ($vote) {
+            $this->pushUpdatedOption($vote->option);
+        }
+
         return $poll;
     }
 
     /**
-     * @param $vote
+     * Pushes a new vote through websocket. Kept for backward compatibility, but we are no longer using it
+     *
+     * @param PollVote $vote
      *
      * @throws \Pusher\PusherException
      */
@@ -83,6 +117,25 @@ class VotePollHandler
     {
         if ($pusher = $this->getPusher()) {
             $pusher->trigger('public', 'newPollVote', $vote);
+        }
+    }
+
+    /**
+     * Pushes an updated option through websocket
+     *
+     * @param PollOption $option
+     *
+     * @throws \Pusher\PusherException
+     */
+    public function pushUpdatedOption(PollOption $option)
+    {
+        if ($pusher = $this->getPusher()) {
+            $pusher->trigger('public', 'updatedPollOption', [
+                'pollId' => $option->poll->id,
+                'pollVoteCount' => $option->poll->vote_count,
+                'optionId' => $option->id,
+                'optionVoteCount' => $option->vote_count,
+            ]);
         }
     }
 

--- a/src/Commands/VotePollHandler.php
+++ b/src/Commands/VotePollHandler.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -76,7 +76,7 @@ class VotePollHandler
                 $vote->save();
             } else {
                 $vote = $poll->votes()->create([
-                    'user_id' => $actor->id,
+                    'user_id'   => $actor->id,
                     'option_id' => $optionId,
                 ]);
             }
@@ -107,7 +107,7 @@ class VotePollHandler
     }
 
     /**
-     * Pushes a new vote through websocket. Kept for backward compatibility, but we are no longer using it
+     * Pushes a new vote through websocket. Kept for backward compatibility, but we are no longer using it.
      *
      * @param PollVote $vote
      *
@@ -121,7 +121,7 @@ class VotePollHandler
     }
 
     /**
-     * Pushes an updated option through websocket
+     * Pushes an updated option through websocket.
      *
      * @param PollOption $option
      *
@@ -131,9 +131,9 @@ class VotePollHandler
     {
         if ($pusher = $this->getPusher()) {
             $pusher->trigger('public', 'updatedPollOption', [
-                'pollId' => $option->poll->id,
-                'pollVoteCount' => $option->poll->vote_count,
-                'optionId' => $option->id,
+                'pollId'          => $option->poll->id,
+                'pollVoteCount'   => $option->poll->vote_count,
+                'optionId'        => $option->id,
                 'optionVoteCount' => $option->vote_count,
             ]);
         }

--- a/src/Console/RefreshVoteCountCommand.php
+++ b/src/Console/RefreshVoteCountCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Polls\Console;
 
 use FoF\Polls\Poll;

--- a/src/Console/RefreshVoteCountCommand.php
+++ b/src/Console/RefreshVoteCountCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FoF\Polls\Console;
+
+use FoF\Polls\Poll;
+use FoF\Polls\PollOption;
+use Illuminate\Console\Command;
+
+class RefreshVoteCountCommand extends Command
+{
+    protected $signature = 'fof:polls:refresh';
+
+    protected $description = 'Re-calculate the total number of votes per option';
+
+    public function handle()
+    {
+        $progress = $this->output->createProgressBar(Poll::query()->count() + PollOption::query()->count());
+
+        Poll::query()->each(function (Poll $poll) use ($progress) {
+            $poll->refreshVoteCount()->save();
+
+            $progress->advance();
+        });
+
+        PollOption::query()->each(function (PollOption $option) use ($progress) {
+            $option->refreshVoteCount()->save();
+
+            $progress->advance();
+        });
+
+        $progress->finish();
+
+        $this->info('Done.');
+    }
+}

--- a/src/Events/PollWasCreated.php
+++ b/src/Events/PollWasCreated.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Events/PollWasVoted.php
+++ b/src/Events/PollWasVoted.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Listeners/SavePollsToDatabase.php
+++ b/src/Listeners/SavePollsToDatabase.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Migrations/AbstractMigration.php
+++ b/src/Migrations/AbstractMigration.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,18 +17,17 @@ use Flarum\User\User;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
- * @property int            $id
- * @property string         $question
- * @property bool           $public_poll
- * @property int            $vote_count
- * @property Discussion     $discussion
- * @property User           $user
- * @property int            $discussion_id
- * @property int            $user_id
- * @property \Carbon\Carbon $end_date
- * @property \Carbon\Carbon $created_at
- * @property \Carbon\Carbon $updated_at
- *
+ * @property int                   $id
+ * @property string                $question
+ * @property bool                  $public_poll
+ * @property int                   $vote_count
+ * @property Discussion            $discussion
+ * @property User                  $user
+ * @property int                   $discussion_id
+ * @property int                   $user_id
+ * @property \Carbon\Carbon        $end_date
+ * @property \Carbon\Carbon        $created_at
+ * @property \Carbon\Carbon        $updated_at
  * @property PollVote[]|Collection $votes
  * @property PollVote[]|Collection $myVotes
  */

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -14,18 +14,23 @@ namespace FoF\Polls;
 use Flarum\Database\AbstractModel;
 use Flarum\Discussion\Discussion;
 use Flarum\User\User;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @property int            $id
  * @property string         $question
  * @property bool           $public_poll
+ * @property int            $vote_count
  * @property Discussion     $discussion
- * @property USer           $user
+ * @property User           $user
  * @property int            $discussion_id
  * @property int            $user_id
  * @property \Carbon\Carbon $end_date
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
+ *
+ * @property PollVote[]|Collection $votes
+ * @property PollVote[]|Collection $myVotes
  */
 class Poll extends AbstractModel
 {
@@ -100,5 +105,26 @@ class Poll extends AbstractModel
     public function votes()
     {
         return $this->hasMany(PollVote::class);
+    }
+
+    public function refreshVoteCount(): self
+    {
+        $this->vote_count = $this->votes()->count();
+
+        return $this;
+    }
+
+    protected static $stateUser;
+
+    public function myVotes(User $user = null)
+    {
+        $user = $user ?: static::$stateUser;
+
+        return $this->votes()->where('user_id', $user ? $user->id : null);
+    }
+
+    public static function setStateUser(User $user)
+    {
+        static::$stateUser = $user;
     }
 }

--- a/src/PollOption.php
+++ b/src/PollOption.php
@@ -18,6 +18,7 @@ use Flarum\Database\AbstractModel;
  * @property string         $answer
  * @property Poll           $poll
  * @property int            $poll_id
+ * @property int            $vote_count
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */
@@ -56,6 +57,13 @@ class PollOption extends AbstractModel
 
     public function votes()
     {
-        return $this->hasMany(PollVote::class);
+        return $this->hasMany(PollVote::class, 'option_id');
+    }
+
+    public function refreshVoteCount(): self
+    {
+        $this->vote_count = $this->votes()->count();
+
+        return $this;
     }
 }

--- a/src/PollOption.php
+++ b/src/PollOption.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/PollVote.php
+++ b/src/PollVote.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Validators/PollOptionValidator.php
+++ b/src/Validators/PollOptionValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Validators/PollValidator.php
+++ b/src/Validators/PollValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of fof/polls.
  *
- * Copyright (c) 2019 FriendsOfFlarum.
+ * Copyright (c) FriendsOfFlarum.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
This is commissioned work to improve performance on forums with many voters.

**Changes proposed in this pull request:**
Instead of loading the full list of votes for every poll, set `vote_count` on polls and options and use that to display stats.

To know what the user voted, a new `myVotes` relationship is added. I made the choice to use plural as it's basically just as simple in the backend and will require less changes if we decide to allow voting on multiple options at once in the future.

I had to rework the Pusher logic to broadcast the vote count update instead of the vote object itself. I have kept the existing code, but I don't know if anyone relies on the `newPollVote` Pusher message from third-party extensions.

While updating Pusher I noticed the code simply wasn't working. The `Pusher` class is not `\Pusher\Pusher`, but just `\Pusher`, so I made the change to fix that. That Pusher code still looks very bad, I'm assuming it's compatible with both Pusher and Websockets extensions? I don't have Websockets to test though.

The `poll.votes` includes are still there, but are now optional includes. They are still used when clicking on the voters modal.

The changes not only improve performance, they will also allow actually implementing the "public" vote visibility and add a new permission to prevent changing vote in my next PRs.

**Reviewers should focus on:**
Do you think this brings any breaking changes for other extensions? I'm only aware of one extension made by me that might be impacted by the changes here.

**Confirmed**

Tested both with and without Pusher.