### PR TITLE
Add permissions to view count, view votes and change vote

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -73,4 +73,7 @@ return [
 
     (new Extend\Console())
         ->command(Console\RefreshVoteCountCommand::class),
+
+    (new Extend\Policy())
+        ->modelPolicy(Poll::class, Access\PollPolicy::class),
 ];

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -5,11 +5,11 @@ app.initializers.add('fof/polls', () => {
         .for('fof-polls')
         .registerPermission(
             {
-                icon: 'fa fa-pencil-alt',
-                label: app.translator.trans('fof-polls.admin.permissions.moderate'),
-                permission: 'discussion.polls',
+                icon: 'fa fa-signal',
+                label: app.translator.trans('fof-polls.admin.permissions.view_results_without_voting'),
+                permission: 'viewPollResultsWithoutVoting',
             },
-            'moderate'
+            'view'
         )
         .registerPermission(
             {
@@ -25,7 +25,7 @@ app.initializers.add('fof/polls', () => {
                 label: app.translator.trans('fof-polls.admin.permissions.self_edit'),
                 permission: 'selfEditPolls',
             },
-            'reply'
+            'start'
         )
         .registerPermission(
             {
@@ -34,5 +34,21 @@ app.initializers.add('fof/polls', () => {
                 permission: 'votePolls',
             },
             'reply'
+        )
+        .registerPermission(
+            {
+                icon: 'fa fa-signal',
+                label: app.translator.trans('fof-polls.admin.permissions.change_vote'),
+                permission: 'changeVotePolls',
+            },
+            'reply'
+        )
+        .registerPermission(
+            {
+                icon: 'fa fa-pencil-alt',
+                label: app.translator.trans('fof-polls.admin.permissions.moderate'),
+                permission: 'discussion.polls',
+            },
+            'moderate'
         );
 });

--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -13,6 +13,7 @@ export default class DiscussionPoll extends Component {
 
     view() {
         const hasVoted = this.myVotes.length > 0;
+        const totalVotes = this.poll.voteCount();
 
         return (
             <div>
@@ -21,25 +22,25 @@ export default class DiscussionPoll extends Component {
                 {this.options.map((opt) => {
                     const voted = this.myVotes.some(vote => vote.option() === opt);
                     const votes = opt.voteCount();
-                    const percent = Math.round((votes / this.poll.voteCount()) * 100);
+                    const percent = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
 
-                    const title = hasVoted && app.translator.transChoice('fof-polls.forum.tooltip.votes', votes, {count: String(votes)}).join('');
+                    const title = isNaN(votes) ? '' : app.translator.transChoice('fof-polls.forum.tooltip.votes', votes, {count: String(votes)}).join('');
 
                     return (
                         <div className={`PollOption ${hasVoted && 'PollVoted'} ${this.poll.hasEnded() && 'PollEnded'}`}>
                             <div title={title} className="PollBar" data-selected={voted}>
                                 {((!this.poll.hasEnded() && app.session.user && app.session.user.canVotePolls()) || !app.session.user) && (
                                     <label className="checkbox">
-                                        <input onchange={this.changeVote.bind(this, opt)} type="checkbox" checked={voted} />
+                                        <input onchange={this.changeVote.bind(this, opt)} type="checkbox" checked={voted} disabled={hasVoted && !this.poll.canChangeVote()} />
                                         <span className="checkmark" />
                                     </label>
                                 )}
 
-                                <div style={hasVoted && '--width: ' + percent + '%'} className="PollOption-active" />
+                                <div style={!isNaN(votes) && '--width: ' + percent + '%'} className="PollOption-active" />
                                 <label className="PollAnswer">
                                     <span>{opt.answer()}</span>
                                 </label>
-                                {hasVoted && (
+                                {!isNaN(votes) && (
                                     <label>
                                         <span className={percent !== 100 ? 'PollPercent PollPercent--option' : 'PollPercent'}>{percent}%</span>
                                     </label>
@@ -51,7 +52,7 @@ export default class DiscussionPoll extends Component {
 
                 <div style="clear: both;" />
 
-                {this.poll.publicPoll()
+                {this.poll.canSeeVotes()
                     ? Button.component(
                           {
                               className: 'Button Button--primary PublicPollButton',

--- a/js/src/forum/components/ListVotersModal.js
+++ b/js/src/forum/components/ListVotersModal.js
@@ -16,8 +16,7 @@ export default class ListVotersModal extends Modal {
             <div className="Modal-body">
                 <ul className="VotesModal-list">
                     {this.attrs.poll.options().map((opt) => {
-                        const votes = this.attrs.poll
-                            .votes()
+                        const votes = (this.attrs.poll.votes() || [])
                             .filter((v) => opt.id() === v.option().id())
                             .map((v) => v.user());
 

--- a/js/src/forum/models/Poll.js
+++ b/js/src/forum/models/Poll.js
@@ -7,6 +7,8 @@ export default class Poll extends mixin(Model, {
     endDate: Model.attribute('endDate'),
     publicPoll: Model.attribute('publicPoll'),
     voteCount: Model.attribute('voteCount'),
+    canSeeVotes: Model.attribute('canSeeVotes'),
+    canChangeVote: Model.attribute('canChangeVote'),
 
     options: Model.hasMany('options'),
     votes: Model.hasMany('votes'),

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -196,6 +196,10 @@
       &:checked ~ .checkmark:after {
         display: block;
       }
+
+      &[disabled] ~ .checkmark {
+        cursor: not-allowed;
+      }
     }
 
     .checkmark {

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,10 +1,12 @@
 fof-polls:
   admin:
     permissions:
-      moderate: Edit & remove polls
-      self_edit: Allow users to edit their own polls
+      view_results_without_voting: View results without voting
       start: Start a poll
+      self_edit: Allow users to edit their own polls
       vote: Vote on polls
+      change_vote: Change vote
+      moderate: Edit & remove polls
 
   forum:
     days_remaining: Poll ends {time}.

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\Polls\Access;
 
 use Flarum\User\Access\AbstractPolicy;

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FoF\Polls\Access;
+
+use Flarum\User\Access\AbstractPolicy;
+use Flarum\User\User;
+use FoF\Polls\Poll;
+
+class PollPolicy extends AbstractPolicy
+{
+    public function seeVoteCount(User $actor, Poll $poll)
+    {
+        if ($actor->can('viewPollResultsWithoutVoting')) {
+            return $this->allow();
+        }
+
+        if ($poll->myVotes($actor)->count()) {
+            return $this->allow();
+        }
+    }
+
+    public function seeVotes(User $actor, Poll $poll)
+    {
+        if ($actor->can('viewPollResultsWithoutVoting')) {
+            return $this->allow();
+        }
+
+        if ($poll->myVotes($actor)->count() && $poll->public_poll) {
+            return $this->allow();
+        }
+    }
+
+    public function changeVote(User $actor, Poll $poll)
+    {
+        if ($actor->hasPermission('changeVotePolls')) {
+            return $this->allow();
+        }
+    }
+}

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -37,7 +37,7 @@ class PollOptionSerializer extends AbstractSerializer
         ];
 
         if ($this->actor->can('seeVoteCount', $option->poll)) {
-            $attributes['voteCount'] = (int)$option->vote_count;
+            $attributes['voteCount'] = (int) $option->vote_count;
         }
 
         return $attributes;

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -30,11 +30,16 @@ class PollOptionSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($option)
     {
-        return [
+        $attributes = [
             'answer'    => $option->answer,
-            'voteCount' => (int) $option->vote_count,
             'createdAt' => $this->formatDate($option->created_at),
             'updatedAt' => $this->formatDate($option->updated_at),
         ];
+
+        if ($this->actor->can('seeVoteCount', $option->poll)) {
+            $attributes['voteCount'] = (int)$option->vote_count;
+        }
+
+        return $attributes;
     }
 }

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -31,18 +31,18 @@ class PollSerializer extends AbstractSerializer
     protected function getDefaultAttributes($poll)
     {
         $attributes = [
-            'question'    => $poll->question,
-            'hasEnded'    => $poll->hasEnded(),
-            'publicPoll'  => (bool) $poll->public_poll,
-            'endDate'     => $this->formatDate($poll->end_date),
-            'createdAt'   => $this->formatDate($poll->created_at),
-            'updatedAt'   => $this->formatDate($poll->updated_at),
-            'canSeeVotes' => $this->actor->can('seeVotes', $poll),
+            'question'      => $poll->question,
+            'hasEnded'      => $poll->hasEnded(),
+            'publicPoll'    => (bool) $poll->public_poll,
+            'endDate'       => $this->formatDate($poll->end_date),
+            'createdAt'     => $this->formatDate($poll->created_at),
+            'updatedAt'     => $this->formatDate($poll->updated_at),
+            'canSeeVotes'   => $this->actor->can('seeVotes', $poll),
             'canChangeVote' => $this->actor->can('changeVote', $poll),
         ];
 
         if ($this->actor->can('seeVoteCount', $poll)) {
-            $attributes['voteCount'] = (int)$poll->vote_count;
+            $attributes['voteCount'] = (int) $poll->vote_count;
         }
 
         return $attributes;

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -30,15 +30,22 @@ class PollSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($poll)
     {
-        return [
+        $attributes = [
             'question'    => $poll->question,
             'hasEnded'    => $poll->hasEnded(),
             'publicPoll'  => (bool) $poll->public_poll,
-            'voteCount'   => (int) $poll->vote_count,
             'endDate'     => $this->formatDate($poll->end_date),
             'createdAt'   => $this->formatDate($poll->created_at),
             'updatedAt'   => $this->formatDate($poll->updated_at),
+            'canSeeVotes' => $this->actor->can('seeVotes', $poll),
+            'canChangeVote' => $this->actor->can('changeVote', $poll),
         ];
+
+        if ($this->actor->can('seeVoteCount', $poll)) {
+            $attributes['voteCount'] = (int)$poll->vote_count;
+        }
+
+        return $attributes;
     }
 
     public function options($model)
@@ -51,6 +58,10 @@ class PollSerializer extends AbstractSerializer
 
     public function votes($model)
     {
+        if ($this->actor->cannot('seeVotes', $model)) {
+            return null;
+        }
+
         return $this->hasMany(
             $model,
             PollVoteSerializer::class

--- a/src/Commands/VotePollHandler.php
+++ b/src/Commands/VotePollHandler.php
@@ -61,6 +61,10 @@ class VotePollHandler
          */
         $vote = $poll->votes()->where('user_id', $actor->id)->first();
 
+        if ($vote) {
+            $actor->assertCan('changeVote', $poll);
+        }
+
         $previousOption = null;
 
         if ($optionId === null && $vote !== null) {


### PR DESCRIPTION
Commissioned work. Depends on #35 

New permissions for additional use cases.

A side-effect is that admins can always see poll results without voting since it's now based on a permission.

Now polls without "public" results will actually prevent getting the list of votes from the API.