### PR TITLE
Fix inconsistency between frontend and backend abilities

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -48,9 +48,9 @@ return [
     (new Extend\ApiSerializer(UserSerializer::class))
         ->attributes(function (UserSerializer $serializer): array {
             return [
-                'canEditPolls'     => $serializer->getActor()->can('discussion.polls'),
+                'canEditPolls'     => $serializer->getActor()->can('discussion.polls'), // Not used by the extension frontend anymore
                 'canStartPolls'    => $serializer->getActor()->can('startPolls'),
-                'canSelfEditPolls' => $serializer->getActor()->can('selfEditPolls'),
+                'canSelfEditPolls' => $serializer->getActor()->can('selfEditPolls'), // Not used by the extension frontend anymore
                 'canVotePolls'     => $serializer->getActor()->can('votePolls'),
             ];
         }),

--- a/js/src/forum/addDiscussionControls.js
+++ b/js/src/forum/addDiscussionControls.js
@@ -8,19 +8,12 @@ export default () => {
     extend(PostControls, 'moderationControls', function (items, post) {
         const discussion = post.discussion();
         const poll = discussion.poll();
-        const user = app.session.user;
 
-        if (
-            !(
-                poll &&
-                ((user && user.canEditPolls()) || (post.user() && post.user().canSelfEditPolls() && post.user().id() === user.id())) &&
-                post.number() === 1
-            )
-        ) {
+        if (!poll) {
             return;
         }
 
-        if (!poll.hasEnded()) {
+        if (poll.canEdit()) {
             items.add(
                 'fof-polls-edit',
                 Button.component(
@@ -33,21 +26,23 @@ export default () => {
             );
         }
 
-        items.add(
-            'fof-polls-remove',
-            Button.component(
-                {
-                    icon: 'fas fa-trash',
-                    onclick: () => {
-                        if (confirm(app.translator.trans('fof-polls.forum.moderation.delete_confirm'))) {
-                            poll.delete().then(() => {
-                                m.redraw.sync();
-                            });
-                        }
+        if (poll.canDelete()) {
+            items.add(
+                'fof-polls-remove',
+                Button.component(
+                    {
+                        icon: 'fas fa-trash',
+                        onclick: () => {
+                            if (confirm(app.translator.trans('fof-polls.forum.moderation.delete_confirm'))) {
+                                poll.delete().then(() => {
+                                    m.redraw.sync();
+                                });
+                            }
+                        },
                     },
-                },
-                app.translator.trans('fof-polls.forum.moderation.delete')
-            )
-        );
+                    app.translator.trans('fof-polls.forum.moderation.delete')
+                )
+            );
+        }
     });
 };

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -19,9 +19,7 @@ app.initializers.add('fof/polls', () => {
 
     app.store.models.discussions.prototype.poll = Model.hasOne('poll');
 
-    app.store.models.users.prototype.canEditPolls = Model.attribute('canEditPolls');
     app.store.models.users.prototype.canStartPolls = Model.attribute('canStartPolls');
-    app.store.models.users.prototype.canSelfEditPolls = Model.attribute('canSelfEditPolls');
     app.store.models.users.prototype.canVotePolls = Model.attribute('canVotePolls');
 
     addDiscussionBadge();

--- a/js/src/forum/models/Poll.js
+++ b/js/src/forum/models/Poll.js
@@ -6,6 +6,8 @@ export default class Poll extends Model {
     endDate = Model.attribute('endDate');
     publicPoll = Model.attribute('publicPoll');
     voteCount = Model.attribute('voteCount');
+    canEdit = Model.attribute('canEdit');
+    canDelete = Model.attribute('canDelete');
     canSeeVotes = Model.attribute('canSeeVotes');
     canChangeVote = Model.attribute('canChangeVote');
 

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -35,10 +35,37 @@ class PollPolicy extends AbstractPolicy
         }
     }
 
+    public function vote(User $actor, Poll $poll)
+    {
+        if ($actor->hasPermission('votePolls') && !$poll->hasEnded()) {
+            return $this->allow();
+        }
+    }
+
     public function changeVote(User $actor, Poll $poll)
     {
         if ($actor->hasPermission('changeVotePolls')) {
             return $this->allow();
         }
+    }
+
+    public function edit(User $actor, Poll $poll)
+    {
+        if ($actor->hasPermission('discussion.polls')) {
+            return $this->allow();
+        }
+
+        if ($actor->hasPermission('selfEditPolls') && !$poll->hasEnded()) {
+            $ownerId = $poll->discussion->user_id;
+
+            if ($ownerId && $ownerId === $actor->id) {
+                return $this->allow();
+            }
+        }
+    }
+
+    public function delete(User $actor, Poll $poll)
+    {
+        return $this->edit($actor, $poll);
     }
 }

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -37,6 +37,8 @@ class PollSerializer extends AbstractSerializer
             'endDate'       => $this->formatDate($poll->end_date),
             'createdAt'     => $this->formatDate($poll->created_at),
             'updatedAt'     => $this->formatDate($poll->updated_at),
+            'canEdit'       => $this->actor->can('edit', $poll),
+            'canDelete'     => $this->actor->can('delete', $poll),
             'canSeeVotes'   => $this->actor->can('seeVotes', $poll),
             'canChangeVote' => $this->actor->can('changeVote', $poll),
         ];

--- a/src/Commands/DeletePollHandler.php
+++ b/src/Commands/DeletePollHandler.php
@@ -11,38 +11,18 @@
 
 namespace FoF\Polls\Commands;
 
-use Flarum\User\Exception\PermissionDeniedException;
-use Flarum\User\User;
 use FoF\Polls\Poll;
-use Illuminate\Contracts\Events\Dispatcher;
 
 class DeletePollHandler
 {
-    /**
-     * @var Dispatcher
-     */
-    private $events;
-
-    /**
-     * @param Dispatcher $events
-     */
-    public function __construct(Dispatcher $events)
-    {
-        $this->events = $events;
-    }
-
     public function handle(DeletePoll $command)
     {
         /**
-         * @var User
+         * @var $poll Poll
          */
-        $actor = $command->actor;
         $poll = Poll::findOrFail($command->pollId);
 
-        if (!$actor->can('edit.polls')
-            && !($actor->id === $poll->user->id && $actor->can('selfEditPolls'))) {
-            throw new PermissionDeniedException();
-        }
+        $command->actor->assertCan('delete', $poll);
 
         $poll->delete();
     }

--- a/src/Commands/EditPollHandler.php
+++ b/src/Commands/EditPollHandler.php
@@ -12,46 +12,21 @@
 namespace FoF\Polls\Commands;
 
 use Carbon\Carbon;
-use Flarum\User\Exception\PermissionDeniedException;
-use Flarum\User\User;
 use FoF\Polls\Poll;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 
 class EditPollHandler
 {
-    /**
-     * @var Dispatcher
-     */
-    private $events;
-
-    /**
-     * @param Dispatcher $events
-     */
-    public function __construct(Dispatcher $events)
-    {
-        $this->events = $events;
-    }
-
     public function handle(EditPoll $command)
     {
         /**
-         * @var User
+         * @var $poll Poll
          */
-        $actor = $command->actor;
         $poll = Poll::findOrFail($command->pollId);
-        $data = $command->data;
 
-        if ($poll->hasEnded()) {
-            throw new PermissionDeniedException();
-        }
+        $command->actor->assertCan('edit', $poll);
 
-        if (!$actor->can('edit.polls')
-            && !($actor->id === $poll->user->id && $actor->can('selfEditPolls'))) {
-            throw new PermissionDeniedException();
-        }
-
-        $attributes = Arr::get($data, 'attributes', []);
+        $attributes = Arr::get($command->data, 'attributes', []);
         $options = collect(Arr::get($attributes, 'options', []));
 
         if (isset($attributes['question'])) {

--- a/src/Commands/VotePollHandler.php
+++ b/src/Commands/VotePollHandler.php
@@ -12,7 +12,6 @@
 namespace FoF\Polls\Commands;
 
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\Exception\PermissionDeniedException;
 use FoF\Polls\Events\PollWasVoted;
 use FoF\Polls\Poll;
 use FoF\Polls\PollOption;

--- a/src/Commands/VotePollHandler.php
+++ b/src/Commands/VotePollHandler.php
@@ -62,11 +62,7 @@ class VotePollHandler
 
         $optionId = Arr::get($data, 'optionId');
 
-        $actor->assertCan('votePolls');
-
-        if ($poll->hasEnded()) {
-            throw new PermissionDeniedException();
-        }
+        $actor->assertCan('vote', $poll);
 
         /**
          * @var $vote PollVote|null


### PR DESCRIPTION
**Changes proposed in this pull request:**
Use a policy for vote, edit and delete abilities, and use that value in the serializer for the frontend to unify the checks in backend and frontend.

Vote: nothing changed, just moved to policy
Edit: frontend behavior was kept (added ended check to backend, fixed moderator ability to edit)
Delete: behavior has been made to match edit (previously you would not see the edit button for ended poll but you would for delete)

**Reviewers should focus on:**
`edit.posts` ability has been renamed to `discussion.polls`, which seem to be the correct permission name. There has never been any setting in the admin for any permission named `edit.posts`, so the old check was essentially just allowing admins, but never other users you might have given Moderate ability to.

Now editing and deleting is actually prevented if the poll has ended. Previously the button would be hidden client-side but you could still edit/delete via the API.

Should we keep exposing the permissions through the user serializer? Two of the permissions are now no longer used by our frontends, but other extensions might, including https://github.com/clarkwinkelmann/flarum-ext-quiz-polls (I'll patch it though)