### PR TITLE
Use ComposerState fields to hold poll data

### DIFF
--- a/js/src/forum/addDiscussionComposerItem.js
+++ b/js/src/forum/addDiscussionComposerItem.js
@@ -9,8 +9,8 @@ import CreatePollModal from './components/CreatePollModal';
 export default () => {
   DiscussionComposer.prototype.addPoll = function () {
     app.modal.show(CreatePollModal, {
-      poll: this.poll,
-      onsubmit: (poll) => (this.poll = poll),
+      poll: this.composer.fields.poll,
+      onsubmit: (poll) => (this.composer.fields.poll = poll),
     });
   };
 
@@ -20,8 +20,8 @@ export default () => {
       items.add(
         'polls',
         <a className="DiscussionComposer-poll" onclick={this.addPoll.bind(this)}>
-          <span className={classList('PollLabel', !this.poll && 'none')}>
-            {app.translator.trans(`fof-polls.forum.composer_discussion.${this.poll ? 'edit' : 'add'}_poll`)}
+          <span className={classList('PollLabel', !this.composer.fields.poll && 'none')}>
+            {app.translator.trans(`fof-polls.forum.composer_discussion.${this.composer.fields.poll ? 'edit' : 'add'}_poll`)}
           </span>
         </a>,
         1
@@ -30,8 +30,8 @@ export default () => {
   });
 
   extend(DiscussionComposer.prototype, 'data', function (data) {
-    if (this.poll) {
-      data.poll = this.poll;
+    if (this.composer.fields.poll) {
+      data.poll = this.composer.fields.poll;
     }
   });
 };


### PR DESCRIPTION
**Changes proposed in this pull request:**
Switches from a local variable on the `DiscussionComposer` to the official Flarum fields API on `ComposerState`.

This enables other extensions to read and modify the data, and most importantly for me this allows destroying and re-creating the Composer component without loosing the data which I need for another of my extensions.

**Reviewers should focus on:**
Any backward compatibility necessary? Probably not.

The only extension I know that hooks into Polls is my own https://github.com/clarkwinkelmann/flarum-ext-quiz-polls which is not impacted by this change.

**Screenshot**
No visual change

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
