### PR TITLE
Update addDiscussionBadge.js

### DIFF
--- a/js/src/forum/addDiscussionBadge.js
+++ b/js/src/forum/addDiscussionBadge.js
@@ -17,7 +17,7 @@ export default () => {
         Badge.component({
           type: 'poll',
           label: app.translator.trans('fof-polls.forum.tooltip.badge'),
-          icon: 'fa fa-signal',
+          icon: 'fas fa-signal',
         }),
         5
       );


### PR DESCRIPTION
**Changes proposed in this pull request:**
changed the fa prefix to fas to support FA 6

**Reviewers should focus on:**
compatibility for earlier FA versions

**Confirmed**
Frontend changes: tested on a local Flarum installation.

