### PR TITLE
Option images and more extensibility

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -75,4 +75,7 @@ return [
 
     (new Extend\Policy())
         ->modelPolicy(Poll::class, Access\PollPolicy::class),
+
+    (new Extend\Settings())
+        ->serializeToForum('allowPollOptionImage', 'fof-polls.allowOptionImage', 'boolval'),
 ];

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -3,6 +3,11 @@ import app from 'flarum/admin/app';
 app.initializers.add('fof/polls', () => {
   app.extensionData
     .for('fof-polls')
+    .registerSetting({
+      setting: 'fof-polls.allowOptionImage',
+      type: 'switch',
+      label: app.translator.trans('fof-polls.admin.settings.allow_option_image'),
+    })
     .registerPermission(
       {
         icon: 'fas fa-signal',

--- a/js/src/forum/components/CreatePollModal.js
+++ b/js/src/forum/components/CreatePollModal.js
@@ -156,13 +156,15 @@ export default class CreatePollModal extends Modal {
             bidi={this.options[i]}
             placeholder={app.translator.trans('fof-polls.forum.modal.option_placeholder') + ' #' + (i + 1)}
           />
-          <input
-            className="FormControl"
-            type="text"
-            name={'answerImage' + (i + 1)}
-            bidi={this.optionImageUrls[i]}
-            placeholder={app.translator.trans('fof-polls.forum.modal.image_option_placeholder') + ' #' + (i + 1)}
-          />
+          {app.forum.attribute('allowPollOptionImage') ? (
+            <input
+              className="FormControl"
+              type="text"
+              name={'answerImage' + (i + 1)}
+              bidi={this.optionImageUrls[i]}
+              placeholder={app.translator.trans('fof-polls.forum.modal.image_option_placeholder') + ' #' + (i + 1)}
+            />
+          ) : null}
         </fieldset>
         {i >= 2
           ? Button.component({

--- a/js/src/forum/components/CreatePollModal.js
+++ b/js/src/forum/components/CreatePollModal.js
@@ -20,13 +20,13 @@ export default class CreatePollModal extends Modal {
 
     this.publicPoll = Stream(false);
 
-    const {poll} = this.attrs;
+    const { poll } = this.attrs;
 
     // When re-opening the modal for the same discussion composer where we already set poll attributes
     if (poll && Array.isArray(poll.options)) {
       this.options = [];
       this.optionImageUrls = [];
-      poll.options.forEach(option => {
+      poll.options.forEach((option) => {
         this.options.push(Stream(option.answer));
         this.optionImageUrls.push(Stream(option.imageUrl));
       });
@@ -60,9 +60,7 @@ export default class CreatePollModal extends Modal {
   content() {
     return [
       <div className="Modal-body">
-        <div className="PollDiscussionModal-form">
-          {this.fields().toArray()}
-        </div>
+        <div className="PollDiscussionModal-form">{this.fields().toArray()}</div>
       </div>,
     ];
   }
@@ -70,59 +68,79 @@ export default class CreatePollModal extends Modal {
   fields() {
     const items = new ItemList();
 
-    items.add('question', <div className="Form-group">
-      <label className="label">{app.translator.trans('fof-polls.forum.modal.question_placeholder')}</label>
+    items.add(
+      'question',
+      <div className="Form-group">
+        <label className="label">{app.translator.trans('fof-polls.forum.modal.question_placeholder')}</label>
 
-      <input type="text" name="question" className="FormControl" bidi={this.question} />
-    </div>, 100);
+        <input type="text" name="question" className="FormControl" bidi={this.question} />
+      </div>,
+      100
+    );
 
-    items.add('answers', <div className="PollModal--answers Form-group">
-      <label className="label PollModal--answers-title">
-        <span>{app.translator.trans('fof-polls.forum.modal.options_label')}</span>
+    items.add(
+      'answers',
+      <div className="PollModal--answers Form-group">
+        <label className="label PollModal--answers-title">
+          <span>{app.translator.trans('fof-polls.forum.modal.options_label')}</span>
 
-        {Button.component({
-          className: 'Button PollModal--button small',
-          icon: 'fas fa-plus',
-          onclick: this.addOption.bind(this),
-        })}
-      </label>
+          {Button.component({
+            className: 'Button PollModal--button small',
+            icon: 'fas fa-plus',
+            onclick: this.addOption.bind(this),
+          })}
+        </label>
 
-      {this.displayOptions()}
-    </div>, 80);
+        {this.displayOptions()}
+      </div>,
+      80
+    );
 
-    items.add('date', <div className="Form-group">
-      <label className="label">{app.translator.trans('fof-polls.forum.modal.date_placeholder')}</label>
+    items.add(
+      'date',
+      <div className="Form-group">
+        <label className="label">{app.translator.trans('fof-polls.forum.modal.date_placeholder')}</label>
 
-      <div className="PollModal--date" oncreate={this.configDatePicker.bind(this)}>
-        <input style="opacity: 1; color: inherit" className="FormControl" data-input />
-        {Button.component({
-          className: 'Button PollModal--button',
-          icon: 'fas fa-times',
-          'data-clear': true,
-        })}
-      </div>
-    </div>, 40);
+        <div className="PollModal--date" oncreate={this.configDatePicker.bind(this)}>
+          <input style="opacity: 1; color: inherit" className="FormControl" data-input />
+          {Button.component({
+            className: 'Button PollModal--button',
+            icon: 'fas fa-times',
+            'data-clear': true,
+          })}
+        </div>
+      </div>,
+      40
+    );
 
-    items.add('public', <div className="Form-group">
-      {Switch.component(
-        {
-          state: this.publicPoll() || false,
-          onchange: this.publicPoll,
-        },
-        app.translator.trans('fof-polls.forum.modal.public_poll_label')
-      )}
-    </div>, 20);
+    items.add(
+      'public',
+      <div className="Form-group">
+        {Switch.component(
+          {
+            state: this.publicPoll() || false,
+            onchange: this.publicPoll,
+          },
+          app.translator.trans('fof-polls.forum.modal.public_poll_label')
+        )}
+      </div>,
+      20
+    );
 
-    items.add('submit', <div className="Form-group">
-      {Button.component(
-        {
-          type: 'submit',
-          className: 'Button Button--primary PollModal-SubmitButton',
-          loading: this.loading,
-        },
-        app.translator.trans('fof-polls.forum.modal.submit')
-      )}
-    </div>, -10);
+    items.add(
+      'submit',
+      <div className="Form-group">
+        {Button.component(
+          {
+            type: 'submit',
+            className: 'Button Button--primary PollModal-SubmitButton',
+            loading: this.loading,
+          },
+          app.translator.trans('fof-polls.forum.modal.submit')
+        )}
+      </div>,
+      -10
+    );
 
     return items;
   }

--- a/js/src/forum/components/CreatePollModal.js
+++ b/js/src/forum/components/CreatePollModal.js
@@ -3,7 +3,7 @@ import app from 'flarum/forum/app';
 import Button from 'flarum/common/components/Button';
 import Modal from 'flarum/common/components/Modal';
 import Switch from 'flarum/common/components/Switch';
-import classList from 'flarum/common/utils/classList';
+import ItemList from 'flarum/common/utils/ItemList';
 import Stream from 'flarum/common/utils/Stream';
 import flatpickr from 'flatpickr';
 
@@ -12,6 +12,7 @@ export default class CreatePollModal extends Modal {
     super.oninit(vnode);
 
     this.options = [Stream(''), Stream('')];
+    this.optionImageUrls = [Stream(''), Stream('')];
 
     this.question = Stream('');
 
@@ -19,10 +20,17 @@ export default class CreatePollModal extends Modal {
 
     this.publicPoll = Stream(false);
 
-    if (this.attrs.poll && this.attrs.poll.relationships) {
-      const poll = this.attrs.poll;
+    const {poll} = this.attrs;
 
-      this.options = poll.relationships.options.map((o) => Stream(o));
+    // When re-opening the modal for the same discussion composer where we already set poll attributes
+    if (poll && Array.isArray(poll.options)) {
+      this.options = [];
+      this.optionImageUrls = [];
+      poll.options.forEach(option => {
+        this.options.push(Stream(option.answer));
+        this.optionImageUrls.push(Stream(option.imageUrl));
+      });
+
       this.question(poll.question);
       this.endDate(!poll.endDate || isNaN(poll.endDate.getTime()) ? null : poll.endDate);
       this.publicPoll(poll.publicPoll);
@@ -53,62 +61,70 @@ export default class CreatePollModal extends Modal {
     return [
       <div className="Modal-body">
         <div className="PollDiscussionModal-form">
-          <div className="Form-group">
-            <label className="label">{app.translator.trans('fof-polls.forum.modal.question_placeholder')}</label>
-
-            <input type="text" name="question" className="FormControl" bidi={this.question} />
-          </div>
-
-          <div className="PollModal--answers Form-group">
-            <label className="label PollModal--answers-title">
-              <span>{app.translator.trans('fof-polls.forum.modal.options_label')}</span>
-
-              {Button.component({
-                className: 'Button PollModal--button small',
-                icon: 'fas fa-plus',
-                onclick: this.addOption.bind(this),
-              })}
-            </label>
-
-            {this.displayOptions()}
-          </div>
-
-          <div className="Form-group">
-            <label className="label">{app.translator.trans('fof-polls.forum.modal.date_placeholder')}</label>
-
-            <div className="PollModal--date" oncreate={this.configDatePicker.bind(this)}>
-              <input style="opacity: 1; color: inherit" className="FormControl" data-input />
-              {Button.component({
-                className: 'Button PollModal--button',
-                icon: 'fas fa-times',
-                'data-clear': true,
-              })}
-            </div>
-          </div>
-
-          <div className="Form-group">
-            {Switch.component(
-              {
-                state: this.publicPoll() || false,
-                onchange: this.publicPoll,
-              },
-              app.translator.trans('fof-polls.forum.modal.public_poll_label')
-            )}
-          </div>
-
-          <div className="Form-group">
-            {Button.component(
-              {
-                type: 'submit',
-                className: 'Button Button--primary PollModal-SubmitButton',
-                loading: this.loading,
-              },
-              app.translator.trans('fof-polls.forum.modal.submit')
-            )}
-          </div>
+          {this.fields().toArray()}
         </div>
       </div>,
     ];
+  }
+
+  fields() {
+    const items = new ItemList();
+
+    items.add('question', <div className="Form-group">
+      <label className="label">{app.translator.trans('fof-polls.forum.modal.question_placeholder')}</label>
+
+      <input type="text" name="question" className="FormControl" bidi={this.question} />
+    </div>, 100);
+
+    items.add('answers', <div className="PollModal--answers Form-group">
+      <label className="label PollModal--answers-title">
+        <span>{app.translator.trans('fof-polls.forum.modal.options_label')}</span>
+
+        {Button.component({
+          className: 'Button PollModal--button small',
+          icon: 'fas fa-plus',
+          onclick: this.addOption.bind(this),
+        })}
+      </label>
+
+      {this.displayOptions()}
+    </div>, 80);
+
+    items.add('date', <div className="Form-group">
+      <label className="label">{app.translator.trans('fof-polls.forum.modal.date_placeholder')}</label>
+
+      <div className="PollModal--date" oncreate={this.configDatePicker.bind(this)}>
+        <input style="opacity: 1; color: inherit" className="FormControl" data-input />
+        {Button.component({
+          className: 'Button PollModal--button',
+          icon: 'fas fa-times',
+          'data-clear': true,
+        })}
+      </div>
+    </div>, 40);
+
+    items.add('public', <div className="Form-group">
+      {Switch.component(
+        {
+          state: this.publicPoll() || false,
+          onchange: this.publicPoll,
+        },
+        app.translator.trans('fof-polls.forum.modal.public_poll_label')
+      )}
+    </div>, 20);
+
+    items.add('submit', <div className="Form-group">
+      {Button.component(
+        {
+          type: 'submit',
+          className: 'Button Button--primary PollModal-SubmitButton',
+          loading: this.loading,
+        },
+        app.translator.trans('fof-polls.forum.modal.submit')
+      )}
+    </div>, -10);
+
+    return items;
   }
 
   displayOptions() {
@@ -121,6 +137,13 @@ export default class CreatePollModal extends Modal {
             name={'answer' + (i + 1)}
             bidi={this.options[i]}
             placeholder={app.translator.trans('fof-polls.forum.modal.option_placeholder') + ' #' + (i + 1)}
+          />
+          <input
+            className="FormControl"
+            type="text"
+            name={'answerImage' + (i + 1)}
+            bidi={this.optionImageUrls[i]}
+            placeholder={app.translator.trans('fof-polls.forum.modal.image_option_placeholder') + ' #' + (i + 1)}
           />
         </fieldset>
         {i >= 2
@@ -141,6 +164,7 @@ export default class CreatePollModal extends Modal {
 
     if (this.options.length < max) {
       this.options.push(Stream(''));
+      this.optionImageUrls.push(Stream(''));
     } else {
       alert(app.translator.trans('fof-polls.forum.modal.max'));
     }
@@ -148,33 +172,51 @@ export default class CreatePollModal extends Modal {
 
   removeOption(option) {
     this.options.splice(option, 1);
+    this.optionImageUrls.splice(option, 1);
+  }
+
+  data() {
+    const poll = {
+      question: this.question(),
+      endDate: this.endDate(),
+      publicPoll: this.publicPoll(),
+      options: [],
+    };
+
+    this.options.forEach((answer, index) => {
+      if (answer()) {
+        poll.options.push({
+          answer: answer(),
+          imageUrl: this.optionImageUrls[index](),
+        });
+      }
+    });
+
+    if (this.question() === '') {
+      alert(app.translator.trans('fof-polls.forum.modal.include_question'));
+
+      return null;
+    }
+
+    if (poll.options.length < 2) {
+      alert(app.translator.trans('fof-polls.forum.modal.min'));
+
+      return null;
+    }
+
+    return poll;
   }
 
   onsubmit(e) {
     e.preventDefault();
 
-    const poll = {
-      question: this.question(),
-      endDate: this.endDate(),
-      publicPoll: this.publicPoll(),
-    };
-    const options = this.options.map((a) => a()).filter(Boolean);
+    const data = this.data();
 
-    if (this.question() === '') {
-      alert(app.translator.trans('fof-polls.forum.modal.include_question'));
-
+    if (data === null) {
       return;
     }
 
-    if (options.length < 2) {
-      alert(app.translator.trans('fof-polls.forum.modal.min'));
-
-      return;
-    }
-
-    poll.relationships = { options };
-
-    this.attrs.onsubmit(poll);
+    this.attrs.onsubmit(data);
 
     app.modal.close();
   }

--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -64,12 +64,7 @@ export default class DiscussionPoll extends Component {
           <div className="PollBar" data-selected={voted}>
             {((!this.poll.hasEnded() && app.session.user && app.session.user.canVotePolls()) || !app.session.user) && (
               <label className="checkbox">
-                <input
-                  onchange={this.changeVote.bind(this, opt)}
-                  type="checkbox"
-                  checked={voted}
-                  disabled={hasVoted && !this.poll.canChangeVote()}
-                />
+                <input onchange={this.changeVote.bind(this, opt)} type="checkbox" checked={voted} disabled={hasVoted && !this.poll.canChangeVote()} />
                 <span className="checkmark" />
               </label>
             )}
@@ -77,7 +72,7 @@ export default class DiscussionPoll extends Component {
             <div style={!isNaN(votes) && '--width: ' + percent + '%'} className="PollOption-active" />
             <label className="PollAnswer">
               <span>{opt.answer()}</span>
-              {opt.imageUrl() ? <img className="PollAnswerImage" src={opt.imageUrl()} alt={opt.answer()}/> : null}
+              {opt.imageUrl() ? <img className="PollAnswerImage" src={opt.imageUrl()} alt={opt.answer()} /> : null}
             </label>
             {!isNaN(votes) && (
               <label>

--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -16,48 +16,11 @@ export default class DiscussionPoll extends Component {
   }
 
   view() {
-    const hasVoted = this.myVotes.length > 0;
-    const totalVotes = this.poll.voteCount();
-
     return (
       <div>
         <h3>{this.poll.question()}</h3>
 
-        {this.options.map((opt) => {
-          const voted = this.myVotes.some((vote) => vote.option() === opt);
-          const votes = opt.voteCount();
-          const percent = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
-
-          return (
-            <div className={classList('PollOption', hasVoted && 'PollVoted', this.poll.hasEnded() && 'PollEnded')}>
-              <Tooltip text={app.translator.trans('fof-polls.forum.tooltip.votes', { count: votes })}>
-                <div className="PollBar" data-selected={voted}>
-                  {((!this.poll.hasEnded() && app.session.user && app.session.user.canVotePolls()) || !app.session.user) && (
-                    <label className="checkbox">
-                      <input
-                        onchange={this.changeVote.bind(this, opt)}
-                        type="checkbox"
-                        checked={voted}
-                        disabled={hasVoted && !this.poll.canChangeVote()}
-                      />
-                      <span className="checkmark" />
-                    </label>
-                  )}
-
-                  <div style={!isNaN(votes) && '--width: ' + percent + '%'} className="PollOption-active" />
-                  <label className="PollAnswer">
-                    <span>{opt.answer()}</span>
-                  </label>
-                  {!isNaN(votes) && (
-                    <label>
-                      <span className={classList('PollPercent', percent !== 100 && 'PollPercent--option')}>{percent}%</span>
-                    </label>
-                  )}
-                </div>
-              </Tooltip>
-            </div>
-          );
-        })}
+        {this.options.map(this.viewOption.bind(this))}
 
         <div style="clear: both;" />
 
@@ -83,6 +46,46 @@ export default class DiscussionPoll extends Component {
         ) : (
           ''
         )}
+      </div>
+    );
+  }
+
+  viewOption(opt) {
+    const hasVoted = this.myVotes.length > 0;
+    const totalVotes = this.poll.voteCount();
+
+    const voted = this.myVotes.some((vote) => vote.option() === opt);
+    const votes = opt.voteCount();
+    const percent = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
+
+    return (
+      <div className={classList('PollOption', hasVoted && 'PollVoted', this.poll.hasEnded() && 'PollEnded')}>
+        <Tooltip text={app.translator.trans('fof-polls.forum.tooltip.votes', { count: votes })}>
+          <div className="PollBar" data-selected={voted}>
+            {((!this.poll.hasEnded() && app.session.user && app.session.user.canVotePolls()) || !app.session.user) && (
+              <label className="checkbox">
+                <input
+                  onchange={this.changeVote.bind(this, opt)}
+                  type="checkbox"
+                  checked={voted}
+                  disabled={hasVoted && !this.poll.canChangeVote()}
+                />
+                <span className="checkmark" />
+              </label>
+            )}
+
+            <div style={!isNaN(votes) && '--width: ' + percent + '%'} className="PollOption-active" />
+            <label className="PollAnswer">
+              <span>{opt.answer()}</span>
+              {opt.imageUrl() ? <img className="PollAnswerImage" src={opt.imageUrl()} alt={opt.answer()}/> : null}
+            </label>
+            {!isNaN(votes) && (
+              <label>
+                <span className={classList('PollPercent', percent !== 100 && 'PollPercent--option')}>{percent}%</span>
+              </label>
+            )}
+          </div>
+        </Tooltip>
       </div>
     );
   }

--- a/js/src/forum/components/EditPollModal.js
+++ b/js/src/forum/components/EditPollModal.js
@@ -12,6 +12,7 @@ export default class EditPollModal extends CreatePollModal {
 
     this.options = this.poll.options();
     this.optionAnswers = this.options.map((o) => Stream(o.answer()));
+    this.optionImageUrls = this.options.map((o) => Stream(o.imageUrl()));
     this.question = Stream(this.poll.question());
     this.endDate = Stream(this.poll.endDate());
     this.publicPoll = Stream(this.poll.publicPoll());
@@ -32,6 +33,13 @@ export default class EditPollModal extends CreatePollModal {
             bidi={this.optionAnswers[i]}
             placeholder={app.translator.trans('fof-polls.forum.modal.option_placeholder') + ' #' + (i + 1)}
           />
+          { app.data['fof-polls.options.images']||true ? <input
+            className="FormControl"
+            type="text"
+            name={'answerImage' + (i + 1)}
+            bidi={this.optionImageUrls[i]}
+            placeholder={app.translator.trans('fof-polls.forum.modal.image_option_placeholder') + ' #' + (i + 1)}
+          /> : null }
         </fieldset>
 
         {i >= 2
@@ -53,6 +61,7 @@ export default class EditPollModal extends CreatePollModal {
     if (this.options.length < max) {
       this.options.push(app.store.createRecord('poll_options'));
       this.optionAnswers.push(Stream(''));
+      this.optionImageUrls.push(Stream(''));
     } else {
       alert(app.translator.trans('fof-polls.forum.modal.max'));
     }
@@ -61,6 +70,25 @@ export default class EditPollModal extends CreatePollModal {
   removeOption(i) {
     this.options.splice(i, 1);
     this.optionAnswers.splice(i, 1);
+    this.optionImageUrls.splice(i, 1);
+  }
+
+  data() {
+    const options = this.options.map((o, i) => {
+      if (!o.data.attributes) o.data.attributes = {};
+
+      o.data.attributes.answer = this.optionAnswers[i]();
+      o.data.attributes.imageUrl = this.optionImageUrls[i]();
+
+      return o.data;
+    });
+
+    return {
+      question: this.question(),
+      endDate: this.endDate() || false,
+      publicPoll: this.publicPoll(),
+      options,
+    };
   }
 
   onsubmit(e) {
@@ -70,21 +98,8 @@ export default class EditPollModal extends CreatePollModal {
 
     this.loading = true;
 
-    const options = this.options.map((o, i) => {
-      if (!o.data.attributes) o.data.attributes = {};
-
-      o.data.attributes.answer = this.optionAnswers[i]();
-
-      return o.data;
-    });
-
     return this.poll
-      .save({
-        question: this.question(),
-        endDate: this.endDate() || false,
-        publicPoll: this.publicPoll(),
-        options,
-      })
+      .save(this.data())
       .then(() => {
         document.location.reload();
       })

--- a/js/src/forum/components/EditPollModal.js
+++ b/js/src/forum/components/EditPollModal.js
@@ -33,13 +33,15 @@ export default class EditPollModal extends CreatePollModal {
             bidi={this.optionAnswers[i]}
             placeholder={app.translator.trans('fof-polls.forum.modal.option_placeholder') + ' #' + (i + 1)}
           />
-          { app.data['fof-polls.options.images']||true ? <input
-            className="FormControl"
-            type="text"
-            name={'answerImage' + (i + 1)}
-            bidi={this.optionImageUrls[i]}
-            placeholder={app.translator.trans('fof-polls.forum.modal.image_option_placeholder') + ' #' + (i + 1)}
-          /> : null }
+          {app.data['fof-polls.options.images'] || true ? (
+            <input
+              className="FormControl"
+              type="text"
+              name={'answerImage' + (i + 1)}
+              bidi={this.optionImageUrls[i]}
+              placeholder={app.translator.trans('fof-polls.forum.modal.image_option_placeholder') + ' #' + (i + 1)}
+            />
+          ) : null}
         </fieldset>
 
         {i >= 2

--- a/js/src/forum/components/EditPollModal.js
+++ b/js/src/forum/components/EditPollModal.js
@@ -33,7 +33,7 @@ export default class EditPollModal extends CreatePollModal {
             bidi={this.optionAnswers[i]}
             placeholder={app.translator.trans('fof-polls.forum.modal.option_placeholder') + ' #' + (i + 1)}
           />
-          {app.data['fof-polls.options.images'] || true ? (
+          {app.forum.attribute('allowPollOptionImage') ? (
             <input
               className="FormControl"
               type="text"

--- a/js/src/forum/components/ListVotersModal.js
+++ b/js/src/forum/components/ListVotersModal.js
@@ -17,9 +17,7 @@ export default class ListVotersModal extends Modal {
   content() {
     return (
       <div className="Modal-body">
-        <ul className="VotesModal-list">
-          {this.attrs.poll.options().map(this.optionContent.bind(this))}
-        </ul>
+        <ul className="VotesModal-list">{this.attrs.poll.options().map(this.optionContent.bind(this))}</ul>
       </div>
     );
   }

--- a/js/src/forum/components/ListVotersModal.js
+++ b/js/src/forum/components/ListVotersModal.js
@@ -7,7 +7,7 @@ import Link from 'flarum/common/components/Link';
 
 export default class ListVotersModal extends Modal {
   className() {
-    return 'Modal--small';
+    return 'Modal--small VotesModal';
   }
 
   title() {
@@ -18,33 +18,38 @@ export default class ListVotersModal extends Modal {
     return (
       <div className="Modal-body">
         <ul className="VotesModal-list">
-          {this.attrs.poll.options().map((opt) => {
-            const votes = (this.attrs.poll.votes() || []).filter((v) => opt.id() === v.option().id()).map((v) => v.user());
-
-            return (
-              <div>
-                <h2>{opt.answer() + ':'}</h2>
-
-                {votes.length ? (
-                  votes.map((u) => {
-                    const attrs = u && { href: app.route.user(u), config: m.route };
-
-                    return (
-                      <li>
-                        <Link {...attrs}>
-                          {avatar(u)} {username(u)}
-                        </Link>
-                      </li>
-                    );
-                  })
-                ) : (
-                  <h4 style="color: #000">{app.translator.trans('fof-polls.forum.modal.no_voters')}</h4>
-                )}
-              </div>
-            );
-          })}
+          {this.attrs.poll.options().map(this.optionContent.bind(this))}
         </ul>
       </div>
+    );
+  }
+
+  optionContent(opt) {
+    const votes = (this.attrs.poll.votes() || []).filter((v) => opt.id() === v.option().id());
+
+    return (
+      <div>
+        <h2>{opt.answer() + ':'}</h2>
+
+        {votes.length ? (
+          votes.map(this.voteContent.bind(this))
+        ) : (
+          <h4 style="color: #000">{app.translator.trans('fof-polls.forum.modal.no_voters')}</h4>
+        )}
+      </div>
+    );
+  }
+
+  voteContent(vote) {
+    const user = vote.user();
+    const attrs = user && { href: app.route.user(user) };
+
+    return (
+      <li>
+        <Link {...attrs}>
+          {avatar(user)} {username(user)}
+        </Link>
+      </li>
     );
   }
 }

--- a/js/src/forum/models/PollOption.js
+++ b/js/src/forum/models/PollOption.js
@@ -2,6 +2,7 @@ import Model from 'flarum/common/Model';
 
 export default class PollOption extends Model {
   answer = Model.attribute('answer');
+  imageUrl = Model.attribute('imageUrl');
   voteCount = Model.attribute('voteCount');
 
   poll = Model.hasOne('polls');

--- a/migrations/2022_10_25_000000_alter_options_add_image.php
+++ b/migrations/2022_10_25_000000_alter_options_add_image.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('poll_options', [
+    'image_url' => ['string', 'length' => 255, 'nullable' => true],
+]);

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -139,6 +139,11 @@
     text-transform: none;
   }
 
+  .PollAnswerImage {
+    display: block; // Put image on its own line below label text
+    max-width: 100%;
+  }
+
   .PollBar {
     background: transparent;
     float: left;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -28,6 +28,7 @@ fof-polls:
       min: You must include a minimum of 2 answers
       no_voters: No Votes
       option_placeholder: Answer
+      image_option_placeholder: Image URL (optional)
       options_label: Answers
       public_poll_label: Allow people to see who voted
       question_placeholder: Question

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -1,5 +1,7 @@
 fof-polls:
   admin:
+    settings:
+      allow_option_image: Allow an image URL to be provided for each poll option
     permissions:
       view_results_without_voting: View results without voting
       start: Start a poll

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -31,10 +31,10 @@ class PollOptionSerializer extends AbstractSerializer
     protected function getDefaultAttributes($option)
     {
         $attributes = [
-            'answer'    => $option->answer,
+            'answer'      => $option->answer,
             'imageUrl'    => $option->image_url,
-            'createdAt' => $this->formatDate($option->created_at),
-            'updatedAt' => $this->formatDate($option->updated_at),
+            'createdAt'   => $this->formatDate($option->created_at),
+            'updatedAt'   => $this->formatDate($option->updated_at),
         ];
 
         if ($this->actor->can('seeVoteCount', $option->poll)) {

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -32,6 +32,7 @@ class PollOptionSerializer extends AbstractSerializer
     {
         $attributes = [
             'answer'    => $option->answer,
+            'imageUrl'    => $option->image_url,
             'createdAt' => $this->formatDate($option->created_at),
             'updatedAt' => $this->formatDate($option->updated_at),
         ];

--- a/src/Commands/EditPollHandler.php
+++ b/src/Commands/EditPollHandler.php
@@ -45,7 +45,7 @@ class EditPollHandler
 
         $command->actor->assertCan('edit', $poll);
 
-        $attributes = (array)Arr::get($command->data, 'attributes');
+        $attributes = (array) Arr::get($command->data, 'attributes');
         $options = collect(Arr::get($attributes, 'options', []));
 
         if (isset($attributes['question'])) {
@@ -93,7 +93,7 @@ class EditPollHandler
             $id = Arr::get($opt, 'id');
 
             $optionAttributes = [
-                'answer' => Arr::get($opt, 'attributes.answer'),
+                'answer'   => Arr::get($opt, 'attributes.answer'),
                 'imageUrl' => Arr::get($opt, 'attributes.imageUrl') ?: null,
             ];
 
@@ -102,7 +102,7 @@ class EditPollHandler
             $poll->options()->updateOrCreate([
                 'id' => $id,
             ], [
-                'answer' => Arr::get($optionAttributes, 'answer'),
+                'answer'    => Arr::get($optionAttributes, 'answer'),
                 'image_url' => Arr::get($optionAttributes, 'imageUrl'),
             ]);
         }

--- a/src/Commands/EditPollHandler.php
+++ b/src/Commands/EditPollHandler.php
@@ -12,6 +12,7 @@
 namespace FoF\Polls\Commands;
 
 use Carbon\Carbon;
+use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Polls\Events\SavingPollAttributes;
 use FoF\Polls\Poll;
 use FoF\Polls\Validators\PollOptionValidator;
@@ -30,10 +31,16 @@ class EditPollHandler
      */
     protected $events;
 
-    public function __construct(PollOptionValidator $optionValidator, Dispatcher $events)
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    public function __construct(PollOptionValidator $optionValidator, Dispatcher $events, SettingsRepositoryInterface $settings)
     {
         $this->optionValidator = $optionValidator;
         $this->events = $events;
+        $this->settings = $settings;
     }
 
     public function handle(EditPoll $command)
@@ -96,6 +103,10 @@ class EditPollHandler
                 'answer'   => Arr::get($opt, 'attributes.answer'),
                 'imageUrl' => Arr::get($opt, 'attributes.imageUrl') ?: null,
             ];
+
+            if (!$this->settings->get('fof-polls.allowOptionImage')) {
+                unset($optionAttributes['imageUrl']);
+            }
 
             $this->optionValidator->assertValid($optionAttributes);
 

--- a/src/Events/SavingPollAttributes.php
+++ b/src/Events/SavingPollAttributes.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Polls\Events;
+
+use Flarum\User\User;
+use FoF\Polls\Poll;
+
+/**
+ * Dispatched while a poll is being saved
+ * This event is triggered in both SavePollsToDatabase and EditPollHandler, which don't have the same data format!
+ * For this reason the "attributes" part of the JSON:API payload is provided as a separate attribute since it's almost identical for both situations
+ *
+ * The create/edit authorization has already been performed when this event is dispatched, so it doesn't need to be checked again
+ *
+ * You should not throw any exception if the poll doesn't exist because this happens after the discussion has already been created and would break email and other extensions
+ */
+class SavingPollAttributes
+{
+    /**
+     * @var User
+     */
+    public $actor;
+
+    /**
+     * @var Poll
+     */
+    public $poll;
+
+    /**
+     * @var array
+     */
+    public $attributes;
+
+    /**
+     * @var array
+     */
+    public $data;
+
+    /**
+     * @param User  $actor
+     * @param Poll  $poll
+     * @param array $attributes
+     * @param array $data
+     */
+    public function __construct(User $actor, Poll $poll, array $attributes, array $data)
+    {
+        $this->actor = $actor;
+        $this->poll = $poll;
+        $this->attributes = $attributes;
+        $this->data = $data;
+    }
+}

--- a/src/Events/SavingPollAttributes.php
+++ b/src/Events/SavingPollAttributes.php
@@ -17,7 +17,7 @@ use FoF\Polls\Poll;
 /**
  * Dispatched while a poll is being saved
  * This event is triggered in both SavePollsToDatabase and EditPollHandler, which don't have the same data format!
- * For this reason the "attributes" part of the JSON:API payload is provided as a separate attribute since it's almost identical for both situations
+ * For this reason the "attributes" part of the JSON:API payload is provided as a separate attribute since it's almost identical for both situations.
  *
  * The create/edit authorization has already been performed when this event is dispatched, so it doesn't need to be checked again
  *

--- a/src/Listeners/SavePollsToDatabase.php
+++ b/src/Listeners/SavePollsToDatabase.php
@@ -61,7 +61,7 @@ class SavePollsToDatabase
 
         $event->actor->assertCan('startPolls');
 
-        $attributes = (array)$event->data['attributes']['poll'];
+        $attributes = (array) $event->data['attributes']['poll'];
 
         // Ideally we would use some JSON:API relationship syntax, but it's just too complicated with Flarum to generate the correct JSON payload
         // Instead we just pass an array of option objects that are each a set of key-value pairs for the option attributes
@@ -73,16 +73,16 @@ class SavePollsToDatabase
         if (is_array($rawOptionsData)) {
             foreach ($rawOptionsData as $rawOptionData) {
                 $optionsData[] = [
-                    'answer' => Arr::get($rawOptionData, 'answer'),
+                    'answer'   => Arr::get($rawOptionData, 'answer'),
                     'imageUrl' => Arr::get($rawOptionData, 'imageUrl') ?: null,
                 ];
             }
         } else {
             // Backward-compatibility with old syntax that only passed an array of strings
             // We are no longer using this syntax in the extension itself
-            foreach ((array)Arr::get($attributes, 'relationships.options') as $answerText) {
+            foreach ((array) Arr::get($attributes, 'relationships.options') as $answerText) {
                 $optionsData[] = [
-                    'answer' => (string)$answerText,
+                    'answer' => (string) $answerText,
                 ];
             }
         }

--- a/src/PollOption.php
+++ b/src/PollOption.php
@@ -16,6 +16,7 @@ use Flarum\Database\AbstractModel;
 /**
  * @property int            $id
  * @property string         $answer
+ * @property string         $image_url
  * @property Poll           $poll
  * @property int            $poll_id
  * @property int            $vote_count
@@ -34,18 +35,19 @@ class PollOption extends AbstractModel
         'updated_at',
     ];
 
-    protected $fillable = ['answer'];
+    protected $fillable = ['answer', 'image_url'];
 
     /**
      * @param $answer
      *
      * @return static
      */
-    public static function build($answer)
+    public static function build($answer, $imageUrl = null)
     {
         $option = new static();
 
         $option->answer = $answer;
+        $option->image_url = $imageUrl;
 
         return $option;
     }

--- a/src/Validators/PollOptionValidator.php
+++ b/src/Validators/PollOptionValidator.php
@@ -18,7 +18,8 @@ class PollOptionValidator extends AbstractValidator
     protected function getRules()
     {
         return [
-            'answer' => 'required',
+            'answer' => ['required', 'string', 'max:255'],
+            'imageUrl' => ['nullable', 'url', 'max:255'],
         ];
     }
 }

--- a/src/Validators/PollOptionValidator.php
+++ b/src/Validators/PollOptionValidator.php
@@ -18,7 +18,7 @@ class PollOptionValidator extends AbstractValidator
     protected function getRules()
     {
         return [
-            'answer' => ['required', 'string', 'max:255'],
+            'answer'   => ['required', 'string', 'max:255'],
             'imageUrl' => ['nullable', 'url', 'max:255'],
         ];
     }


### PR DESCRIPTION
**Changes proposed in this pull request:**
This started as a single feature, but it required many changes and was being worked on at the same time as https://github.com/clarkwinkelmann/flarum-ext-vote-with-money so it ended up being a much larger update, but still mostly backward-compatible.

- Added ability to specify an image URL for each option. The image is displayed below the answer label on the discussion page.
- Add new event to let other extensions hook into the poll saving.
- Add new methods that return vdom or ItemLists to improve frontend extensibility.
- Add validation for answer text (there was no max length and you could exceed the MySQL column).

**Reviewers should focus on:**

This is still not perfect at the moment:

- There is no permission/setting to enable the image feature.
- UI is not really finished, I just added the URL field below the answer field.
- The ItemList change is the only place where the vdom is slightly different from before in case extensions were manualy modifying it
- The REST API format for adding a poll to a discussion changed to accommodate more than one attribute per option. This breaks my Quiz extension but it's not a big deal, it's an otherwise good improvement I think.

**Screenshot**
![image](https://user-images.githubusercontent.com/5264300/198169144-51795b0c-3093-4855-aeca-abc0764dde57.png)
![image](https://user-images.githubusercontent.com/5264300/198169220-8eea1a98-4b8e-4406-8e76-2aee8b7a536c.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
