### PR TITLE
UI improvements

### DIFF
--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -21,10 +21,12 @@ export default class DiscussionPoll extends Component {
     if (maxVotes === 0) maxVotes = this.options.length;
 
     return (
-      <div>
+      <div className="Post-poll">
         <h3>{this.poll.question()}</h3>
 
-        {this.options.map(this.viewOption.bind(this))}
+        <div className="PollOptions">
+          {this.options.map(this.viewOption.bind(this))}
+        </div>
 
         <div style="clear: both;" />
 

--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -94,7 +94,7 @@ export default class DiscussionPoll extends Component {
     );
 
     return (
-      <div className={classList('PollOption', hasVoted && 'PollVoted', this.poll.hasEnded() && 'PollEnded')}>
+      <div className={classList('PollOption', hasVoted && 'PollVoted', this.poll.hasEnded() && 'PollEnded', opt.imageUrl() && 'PollOption-hasImage')}>
         {!isNaN(votes) ? <Tooltip text={app.translator.trans('fof-polls.forum.tooltip.votes', { count: votes })}>{poll}</Tooltip> : poll}
       </div>
     );

--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -24,11 +24,7 @@ export default class DiscussionPoll extends Component {
       <div className="Post-poll">
         <h3>{this.poll.question()}</h3>
 
-        <div className="PollOptions">
-          {this.options.map(this.viewOption.bind(this))}
-        </div>
-
-        <div style="clear: both;" />
+        <div className="PollOptions">{this.options.map(this.viewOption.bind(this))}</div>
 
         {this.poll.canSeeVotes()
           ? Button.component(
@@ -47,16 +43,12 @@ export default class DiscussionPoll extends Component {
               {app.translator.trans('fof-polls.forum.no_permission')}
             </span>
           )}
-          {this.poll.hasEnded() && (
-            <span>
-              <i class="icon fas fa-clock" />
-              {app.translator.trans('fof-polls.forum.poll_ended')}
-            </span>
-          )}
           {this.poll.endDate() !== null && (
             <span>
               <i class="icon fas fa-clock" />
-              {app.translator.trans('fof-polls.forum.days_remaining', { time: dayjs(this.poll.endDate()).fromNow() })}
+              {this.poll.hasEnded()
+                ? app.translator.trans('fof-polls.forum.poll_ended')
+                : app.translator.trans('fof-polls.forum.days_remaining', { time: dayjs(this.poll.endDate()).fromNow() })}
             </span>
           )}
 
@@ -165,14 +157,15 @@ export default class DiscussionPoll extends Component {
 
   showVoters() {
     // Load all the votes only when opening the votes list
-    app.store
-      .find('discussions', this.attrs.discussion.id(), {
-        include: 'poll.votes,poll.votes.user,poll.votes.option',
-      })
-      .then(() => {
-        app.modal.show(ListVotersModal, {
-          poll: this.poll,
-        });
-      });
+    // app.store
+    //   .find('discussions', this.attrs.discussion.id(), {
+    //     include: 'poll.votes,poll.votes.user,poll.votes.option',
+    //   })
+    //   .then(() => {
+    app.modal.show(ListVotersModal, {
+      poll: this.poll,
+      discussion: this.attrs.discussion,
+    });
+    // });
   }
 }

--- a/js/src/forum/components/DiscussionPoll.js
+++ b/js/src/forum/components/DiscussionPoll.js
@@ -157,15 +157,9 @@ export default class DiscussionPoll extends Component {
 
   showVoters() {
     // Load all the votes only when opening the votes list
-    // app.store
-    //   .find('discussions', this.attrs.discussion.id(), {
-    //     include: 'poll.votes,poll.votes.user,poll.votes.option',
-    //   })
-    //   .then(() => {
     app.modal.show(ListVotersModal, {
       poll: this.poll,
       discussion: this.attrs.discussion,
     });
-    // });
   }
 }

--- a/js/src/forum/components/ListVotersModal.js
+++ b/js/src/forum/components/ListVotersModal.js
@@ -4,10 +4,25 @@ import Modal from 'flarum/common/components/Modal';
 import avatar from 'flarum/common/helpers/avatar';
 import username from 'flarum/common/helpers/username';
 import Link from 'flarum/common/components/Link';
+import Stream from 'flarum/common/utils/Stream';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 
 export default class ListVotersModal extends Modal {
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    this.loading = Stream(true);
+
+    app.store
+      .find('discussions', this.attrs.discussion.id(), {
+        include: 'poll.votes,poll.votes.user,poll.votes.option',
+      })
+      .then(() => this.loading(false))
+      .finally(() => m.redraw());
+  }
+
   className() {
-    return 'Modal--small VotesModal';
+    return 'Modal--medium VotesModal';
   }
 
   title() {
@@ -17,7 +32,7 @@ export default class ListVotersModal extends Modal {
   content() {
     return (
       <div className="Modal-body">
-        <ul className="VotesModal-list">{this.attrs.poll.options().map(this.optionContent.bind(this))}</ul>
+        {this.loading() ? <LoadingIndicator /> : <ul className="VotesModal-list">{this.attrs.poll.options().map(this.optionContent.bind(this))}</ul>}
       </div>
     );
   }

--- a/js/src/forum/components/ListVotersModal.js
+++ b/js/src/forum/components/ListVotersModal.js
@@ -30,21 +30,21 @@ export default class ListVotersModal extends Modal {
   }
 
   content() {
-    return (
-      <div className="Modal-body">
-        {this.loading() ? <LoadingIndicator /> : <ul className="VotesModal-list">{this.attrs.poll.options().map(this.optionContent.bind(this))}</ul>}
-      </div>
-    );
+    return <div className="Modal-body">{this.loading() ? <LoadingIndicator /> : this.attrs.poll.options().map(this.optionContent.bind(this))}</div>;
   }
 
   optionContent(opt) {
     const votes = (this.attrs.poll.votes() || []).filter((v) => opt.id() === v.option().id());
 
     return (
-      <div>
+      <div className="VotesModal-option">
         <h2>{opt.answer() + ':'}</h2>
 
-        {votes.length ? votes.map(this.voteContent.bind(this)) : <h4>{app.translator.trans('fof-polls.forum.modal.no_voters')}</h4>}
+        {votes.length ? (
+          <div className="VotesModal-list">{votes.map(this.voteContent.bind(this))}</div>
+        ) : (
+          <h4>{app.translator.trans('fof-polls.forum.modal.no_voters')}</h4>
+        )}
       </div>
     );
   }
@@ -54,11 +54,9 @@ export default class ListVotersModal extends Modal {
     const attrs = user && { href: app.route.user(user) };
 
     return (
-      <li>
-        <Link {...attrs}>
-          {avatar(user)} {username(user)}
-        </Link>
-      </li>
+      <Link {...attrs}>
+        {avatar(user)} {username(user)}
+      </Link>
     );
   }
 }

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -106,10 +106,6 @@
 }
 
 .PollOption {
-  &-hasImage {
-    order: -1;
-  }
-
   & &-active {
     height: 100%;
     left: 0;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -145,9 +145,6 @@
   .PollBar {
     background: transparent;
     padding: 10px;
-    .PollEnded& {
-      padding-left: 10px;
-    }
     position: relative;
     margin-left: 15px;
     border-radius: 4px;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -232,31 +232,43 @@
   }
 }
 
-.VotesModal-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.VotesModal {
+  &-list {
+    display: grid;
+    grid: auto-flow / repeat(auto-fill, minmax(150px, 1fr));
+    column-gap: 10px;
+    row-gap: 10px;
+    margin-bottom: 20px;
+
+    a {
+      color: var(--text-color);
+      font-size: 15px;
+      font-weight: bold;
+      display: block;
+      text-decoration: none;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+
+      &:hover .username {
+        text-decoration: underline;
+      }
+    }
+    .Avatar {
+      .Avatar--size(32px);
+      vertical-align: middle;
+      margin-right: 5px;
+    }
+  }
+
+  h2 {
+    margin-bottom: 15px;
+  }
 
   h4 {
     color: var(--text-color);
-  }
-
-  a {
-    color: var(--text-color);
-    font-size: 15px;
-    font-weight: bold;
-    display: block;
-    margin-bottom: 10px;
-    text-decoration: none;
-
-    &:hover .username {
-      text-decoration: underline;
-    }
-  }
-  .Avatar {
-    .Avatar--size(32px);
-    vertical-align: middle;
-    margin-right: 5px;
+    margin-top: 0;
+    margin-bottom: 20px;
   }
 }
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -97,9 +97,11 @@
 .Post-poll {
   .PollOptions {
     display: grid;
-    grid: auto-flow / repeat(auto-fit, minmax(250px, 1fr));
+    grid: auto-flow / repeat(auto-fit, minmax(~"min(250px, 100%)", 1fr));
     column-gap: 30px;
     row-gap: 15px;
+    margin-left: 15px;
+    align-items: start;
   }
 }
 
@@ -140,13 +142,13 @@
   .PollAnswerImage {
     display: block; // Put image on its own line below label text
     max-width: 100%;
+    margin-top: 10px;
   }
 
   .PollBar {
     background: transparent;
     padding: 10px;
     position: relative;
-    margin-left: 15px;
     border-radius: 4px;
     border: 2px solid @muted-color;
     overflow: hidden;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -106,6 +106,10 @@
 }
 
 .PollOption {
+  &-hasImage {
+    order: -1;
+  }
+
   & &-active {
     height: 100%;
     left: 0;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -94,17 +94,17 @@
   }
 }
 
-.PollOption {
-  margin-bottom: 15px;
-  width: 45%;
-  margin-right: 15px;
-  float: left;
-
-  &:nth-child(odd) {
-    float: right;
+.Post-poll {
+  .PollOptions {
+    display: grid;
+    grid: auto-flow / repeat(auto-fit, minmax(250px, 1fr));
+    column-gap: 30px;
+    row-gap: 15px;
   }
+}
 
-  .PollOption-active {
+.PollOption {
+  & &-active {
     height: 100%;
     left: 0;
     position: absolute;
@@ -123,8 +123,6 @@
 
   /* Percent */
   .PollPercent {
-    float: right;
-    position: relative;
     padding-right: 5px;
   }
 
@@ -146,9 +144,7 @@
 
   .PollBar {
     background: transparent;
-    float: left;
-    width: 85%;
-    padding: 10px 10px 10px 40px;
+    padding: 10px;
     .PollEnded& {
       padding-left: 10px;
     }
@@ -157,6 +153,10 @@
     border-radius: 4px;
     border: 2px solid @muted-color;
     overflow: hidden;
+
+    display: flex;
+    column-gap: 10px;
+    align-items: flex-start;
 
     &:hover {
       background: #f3f3f39e;
@@ -167,14 +167,13 @@
       z-index: 2;
 
       span {
-        padding-left: 15px;
         font-size: 11px;
         line-height: 19px;
         font-weight: 600;
       }
     }
-    .PollAnswer span {
-      padding-left: 0;
+    .PollAnswer {
+      flex-grow: 1;
     }
 
     &[data-selected=true] {
@@ -192,7 +191,6 @@
 
   label.checkbox {
     margin-bottom: 0;
-    margin-left: -40px;
 
     input[type="checkbox"] {
       position: absolute;
@@ -210,7 +208,6 @@
 
     .checkmark {
       position: absolute;
-      margin-left: 10px;
       top: 0;
       left: 0;
       height: 20px;
@@ -266,7 +263,7 @@
 
 .PublicPollButton {
   display: block;
-  margin: 10px 0px 15px 15px;
+  margin: 20px 15px;
 }
 
 .PollInfoText {


### PR DESCRIPTION
**Fixes #8**

**Changes proposed in this pull request:**
- Convert `float` to `grid` for options list and `flex` for the options themselves
- Fix duplicate timing message when the poll timer has ended
- Load votes for votes modal after opening, instead of before
- Improve layout margin & image positioning
- Use grid for voters list in modal

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<details><summary>Details</summary>
<p>

![Screenshot 2023-06-18 183521](https://github.com/FriendsOfFlarum/polls/assets/6401250/bd4713b9-7c0c-469f-bd23-463652ef2deb)
![Screenshot 2023-06-18 183551](https://github.com/FriendsOfFlarum/polls/assets/6401250/8f5c40a1-02cb-4c34-a132-059892943c9b)

</p>
</details> 

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.