### PR TITLE
Allow voting for multiple options without change perm

### DIFF
--- a/js/src/forum/components/CreatePollModal.js
+++ b/js/src/forum/components/CreatePollModal.js
@@ -20,6 +20,7 @@ export default class CreatePollModal extends Modal {
 
     this.publicPoll = Stream(false);
     this.hideVotes = Stream(false);
+    this.allowChangeVote = Stream(true);
     this.allowMultipleVotes = Stream(false);
     this.maxVotes = Stream(0);
 
@@ -39,6 +40,7 @@ export default class CreatePollModal extends Modal {
       this.question(poll.question);
       this.publicPoll(poll.publicPoll);
       this.hideVotes(poll.hideVotes);
+      this.allowChangeVote(poll.allowChangeVote);
       this.allowMultipleVotes(poll.allowMultipleVotes);
       this.maxVotes(poll.maxVotes || 0);
 
@@ -157,6 +159,16 @@ export default class CreatePollModal extends Modal {
     );
 
     items.add(
+      'allow-change-vote',
+      <div className="Form-group">
+        <Switch state={this.allowChangeVote()} onchange={this.allowChangeVote}>
+          {app.translator.trans('fof-polls.forum.modal.allow_change_vote_label')}
+        </Switch>
+      </div>,
+      20
+    );
+
+    items.add(
       'allow-multiple-votes',
       <div className="Form-group">
         {Switch.component(
@@ -256,6 +268,8 @@ export default class CreatePollModal extends Modal {
       question: this.question(),
       endDate: this.dateToTimestamp(this.endDate()),
       publicPoll: this.publicPoll(),
+      hideVotes: this.hideVotes(),
+      allowChangeVote: this.allowChangeVote(),
       allowMultipleVotes: this.allowMultipleVotes(),
       maxVotes: this.maxVotes(),
       options: [],

--- a/js/src/forum/components/CreatePollModal.js
+++ b/js/src/forum/components/CreatePollModal.js
@@ -301,6 +301,7 @@ export default class CreatePollModal extends Modal {
 
       promise.then(this.hide.bind(this), (err) => {
         console.error(err);
+        this.onerror(err);
         this.loaded();
       });
     } else {

--- a/js/src/forum/components/EditPollModal.js
+++ b/js/src/forum/components/EditPollModal.js
@@ -19,6 +19,7 @@ export default class EditPollModal extends CreatePollModal {
     this.publicPoll = Stream(this.poll.publicPoll());
     this.allowMultipleVotes = Stream(this.poll.allowMultipleVotes());
     this.hideVotes = Stream(this.poll.hideVotes());
+    this.allowChangeVote = Stream(this.poll.allowChangeVote());
     this.maxVotes = Stream(this.poll.maxVotes() || 0);
 
     if (this.endDate() && dayjs(this.poll.endDate()).isAfter(dayjs())) {
@@ -97,6 +98,7 @@ export default class EditPollModal extends CreatePollModal {
       endDate: this.dateToTimestamp(this.endDate()),
       publicPoll: this.publicPoll(),
       hideVotes: this.hideVotes(),
+      allowChangeVote: this.allowChangeVote(),
       allowMultipleVotes: this.allowMultipleVotes(),
       maxVotes: this.maxVotes(),
       options,

--- a/js/src/forum/models/Poll.js
+++ b/js/src/forum/models/Poll.js
@@ -7,6 +7,7 @@ export default class Poll extends Model {
 
   publicPoll = Model.attribute('publicPoll');
   hideVotes = Model.attribute('hideVotes');
+  allowChangeVote = Model.attribute('allowChangeVote');
   allowMultipleVotes = Model.attribute('allowMultipleVotes');
   maxVotes = Model.attribute('maxVotes');
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -112,6 +112,24 @@
     align-items: start;
   }
 
+  .Poll-sticky {
+    position: sticky;
+    bottom: 0;
+    padding: 10px 0;
+    margin-left: 15px;
+    margin-top: 10px;
+    display: flex;
+    column-gap: 15px;
+    z-index: 999;
+    .box-shadow(inset 0px 2px 0px 0px fade(@text-color, 20%));
+    background-color: var(--body-bg);
+
+    .PollInfoText {
+      flex-grow: 1;
+      margin-bottom: 0;
+    }
+  }
+
   & + & {
     margin-top: 2em;
   }
@@ -318,15 +336,12 @@
 }
 
 .PollInfoText {
-  margin-left: 15px;
-  margin-top: 20px;
-
   span {
     display: block;
   }
 
   .icon {
-    width: 15px;
+    margin-right: 2.5px;
   }
 }
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -119,6 +119,7 @@
     margin-left: 15px;
     margin-top: 10px;
     display: flex;
+    align-items: flex-start;
     column-gap: 15px;
     z-index: 999;
     background-color: var(--body-bg);

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -121,8 +121,12 @@
     display: flex;
     column-gap: 15px;
     z-index: 999;
-    .box-shadow(inset 0px 2px 0px 0px fade(@text-color, 20%));
     background-color: var(--body-bg);
+    .box-shadow(inset 0px 2px 0px 0px fade(@text-color, 20%));
+
+    &:empty {
+      display: none;
+    }
 
     .PollInfoText {
       flex-grow: 1;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -45,6 +45,7 @@ fof-polls:
       max_votes_label: Max votes per user
       max_votes_help: Set to 0 to allow users to vote for all options.
       hide_votes_label: Hide votes until poll ends
+      allow_change_vote_label: Allow users to change their vote
       question_placeholder: Question
       submit: Submit
 

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -19,6 +19,10 @@ fof-polls:
     public_poll: View voters
     max_votes_allowed: "Poll allows voting for {max, plural, one {# option} other {# options}}."
 
+    poll:
+      cannot_change_vote: You cannot change your vote after voting.
+      submit_button: Vote
+
     composer_discussion:
       add_poll: => fof-polls.forum.moderation.add
       edit_poll: => fof-polls.forum.moderation.edit

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -55,7 +55,7 @@ class PollPolicy extends AbstractPolicy
 
     public function changeVote(User $actor, Poll $poll)
     {
-        if ($actor->hasPermission('polls.changeVote')) {
+        if ($poll->allow_change_vote && $actor->hasPermission('polls.changeVote')) {
             return $this->allow();
         }
     }

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -30,17 +30,18 @@ class PollSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($poll)
     {
+        $canEdit = $this->actor->can('edit', $poll);
+
         $attributes = [
             'question'           => $poll->question,
             'hasEnded'           => $poll->hasEnded(),
-            'publicPoll'         => $poll->public_poll,
             'allowMultipleVotes' => $poll->allow_multiple_votes,
             'maxVotes'           => $poll->max_votes,
             'endDate'            => $this->formatDate($poll->end_date),
             'createdAt'          => $this->formatDate($poll->created_at),
             'updatedAt'          => $this->formatDate($poll->updated_at),
             'canVote'            => $this->actor->can('vote', $poll),
-            'canEdit'            => $this->actor->can('edit', $poll),
+            'canEdit'            => $canEdit,
             'canDelete'          => $this->actor->can('delete', $poll),
             'canSeeVoters'       => $this->actor->can('seeVoters', $poll),
             'canChangeVote'      => $this->actor->can('changeVote', $poll),
@@ -48,6 +49,12 @@ class PollSerializer extends AbstractSerializer
 
         if ($this->actor->can('seeVoteCount', $poll)) {
             $attributes['voteCount'] = (int) $poll->vote_count;
+        }
+
+        if ($canEdit) {
+            $attributes['publicPoll'] = $poll->public_poll;
+            $attributes['hideVotes'] = $poll->hide_votes;
+            $attributes['allowChangeVote'] = $poll->allow_change_vote;
         }
 
         return $attributes;

--- a/src/Commands/CreatePollHandler.php
+++ b/src/Commands/CreatePollHandler.php
@@ -103,7 +103,9 @@ class CreatePollHandler
                 $carbonDate != null ? $carbonDate->utc() : null,
                 Arr::get($attributes, 'publicPoll'),
                 Arr::get($attributes, 'allowMultipleVotes'),
-                Arr::get($attributes, 'maxVotes')
+                Arr::get($attributes, 'maxVotes'),
+                Arr::get($attributes, 'hideVotes'),
+                Arr::get($attributes, 'allowChangeVote'),
             );
 
             $this->events->dispatch(new SavingPollAttributes($command->actor, $poll, $attributes, $attributes));

--- a/src/Commands/EditPollHandler.php
+++ b/src/Commands/EditPollHandler.php
@@ -72,7 +72,7 @@ class EditPollHandler
             $poll->question = $attributes['question'];
         }
 
-        foreach (['publicPoll', 'allowMultipleVotes', 'hideVotes'] as $key) {
+        foreach (['publicPoll', 'allowMultipleVotes', 'hideVotes', 'allowChangeVote'] as $key) {
             if (isset($attributes[$key])) {
                 $poll->settings[Str::snake($key)] = (bool) $attributes[$key];
             }

--- a/src/Poll.php
+++ b/src/Poll.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Arr;
  * @property-read bool             $allow_multiple_votes
  * @property-read int              $max_votes
  * @property-read bool             $hide_votes
+ * @property-read bool             $allow_change_vote
  * @property int                   $vote_count
  * @property Post                  $post
  * @property User                  $user
@@ -70,7 +71,7 @@ class Poll extends AbstractModel
      *
      * @return static
      */
-    public static function build($question, $postId, $actorId, $endDate, $publicPoll, $allowMultipleVotes = false, $maxVotes = 0)
+    public static function build($question, $postId, $actorId, $endDate, $publicPoll, $allowMultipleVotes = false, $maxVotes = 0, $hideVotes = false, $allowChangeVote = true)
     {
         $poll = new static();
 
@@ -82,6 +83,8 @@ class Poll extends AbstractModel
             'public_poll'          => $publicPoll,
             'allow_multiple_votes' => $allowMultipleVotes,
             'max_votes'            => min(0, (int) $maxVotes),
+            'hide_votes'           => $hideVotes,
+            'allow_change_vote'    => $allowChangeVote,
         ];
 
         return $poll;
@@ -166,5 +169,10 @@ class Poll extends AbstractModel
     protected function getHideVotesAttribute(): bool
     {
         return (bool) Arr::get($this->settings, 'hide_votes');
+    }
+
+    protected function getAllowChangeVoteAttribute(): bool
+    {
+        return (bool) Arr::get($this->settings, 'allow_change_vote', true);
     }
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #77**

**Changes proposed in this pull request:**
- Add 'Vote' button that appears only if vote allows multiple votes & user cannot change vote
- Make help text & vote button sticky to bottom of poll options (to help users not miss it!)
- Add poll option to prevent users from changing votes in poll
- Fix poll creation not saving "hide votes" perm from 926bd7c2fec335c236e6ca0de69fc214fc736019 (#2)

**Reviewers should focus on:**
- Not 100% sure if the sticky works on mobile? The mobile responsive emulator on firefox seemed to ignore it. I don't think it's that big of an issue.
- A potential problem is that navigating to another Flarum page will not alert the user that they never voted. I'm wary of using `onbeforeremove` for this since that could alert potentially in other situations. I believe this could maybe be done altering router? That may be too complicated.

**Screenshot**
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/1dfd5579-6b8f-4320-8069-1222e2f87bd5)
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/0b10387e-79c6-4c37-89aa-8eaff421d593)
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/79429c11-8e31-4754-a1ed-7dda063dc763)


**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).