### PR TITLE
Clearly show what options user voted for & make text more readable

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -53,6 +53,7 @@ return [
             foreach ($event->settings as $key => $value) {
                 if ($key === 'fof-polls.optionsColorBlend') {
                     resolve('fof-user-bio.formatter')->flush();
+
                     return;
                 }
             }

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -9,6 +9,12 @@ app.initializers.add('fof/polls', () => {
       label: app.translator.trans('fof-polls.admin.settings.allow_option_image'),
     })
     .registerSetting({
+      setting: 'fof-polls.optionsColorBlend',
+      type: 'switch',
+      label: app.translator.trans('fof-polls.admin.settings.options_color_blend'),
+      help: app.translator.trans('fof-polls.admin.settings.options_color_blend_help'),
+    })
+    .registerSetting({
       setting: 'fof-polls.maxOptions',
       type: 'number',
       label: app.translator.trans('fof-polls.admin.settings.max_options'),

--- a/js/src/forum/components/PostPoll.js
+++ b/js/src/forum/components/PostPoll.js
@@ -7,6 +7,7 @@ import ListVotersModal from './ListVotersModal';
 import classList from 'flarum/common/utils/classList';
 import ItemList from 'flarum/common/utils/ItemList';
 import Tooltip from 'flarum/common/components/Tooltip';
+import icon from 'flarum/common/helpers/icon';
 import EditPollModal from './EditPollModal';
 
 export default class PostPoll extends Component {
@@ -149,24 +150,21 @@ export default class PostPoll extends Component {
     const showCheckmark = !app.session.user || (!poll.hasEnded() && poll.canVote() && (!hasVoted || poll.canChangeVote()));
 
     const bar = (
-      <div className="PollBar" data-selected={voted}>
+      <div className="PollBar" data-selected={!!voted} style={`--poll-option-width: ${width}%`}>
         {showCheckmark && (
-          <label className="checkbox">
+          <label className="PollAnswer-checkbox checkbox">
             <input onchange={this.changeVote.bind(this, opt)} type="checkbox" checked={voted} disabled={isDisabled} />
             <span className="checkmark" />
           </label>
         )}
 
-        <div style={`--width: ${width}%`} className="PollOption-active" />
-        <label className="PollAnswer">
-          <span>{opt.answer()}</span>
-          {opt.imageUrl() ? <img className="PollAnswerImage" src={opt.imageUrl()} alt={opt.answer()} /> : null}
-        </label>
-        {canSeeVoteCount && (
-          <label>
-            <span className={classList('PollPercent', percent !== 100 && 'PollPercent--option')}>{percent}%</span>
-          </label>
-        )}
+        <div className="PollAnswer-text">
+          <span className="PollAnswer-text-answer">{opt.answer()}</span>
+          {voted && !showCheckmark && icon('fas fa-check-circle', { className: 'PollAnswer-check' })}
+          {canSeeVoteCount && <span className={classList('PollPercent', percent !== 100 && 'PollPercent--option')}>{percent}%</span>}
+        </div>
+
+        {opt.imageUrl() ? <img className="PollAnswer-image" src={opt.imageUrl()} alt={opt.answer()} /> : null}
       </div>
     );
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -39,6 +39,10 @@
       background-color: var(--alert-error-bg);
       color: var(--alert-error-color);
     }
+
+    + .FormControl {
+      margin-top: 5px;
+    }
   }
 
   .PollModal--answers {
@@ -115,6 +119,25 @@
     row-gap: 15px;
     margin-left: 15px;
     align-items: start;
+
+    .PollAnswer when (@fof-polls-options-color-blend = true) {
+      &-checkbox, &-text {
+        & when (@config-dark-mode =true) {
+          mix-blend-mode: difference;
+        }
+
+        & when (@config-dark-mode =false) {
+          mix-blend-mode: darken;
+        }
+      }
+    }
+
+    .PollAnswer-text::after {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      content: @fof-polls-options-color-blend ;
+    }
   }
 
   .Poll-sticky {
@@ -217,16 +240,6 @@
     grid-auto-flow: row;
     gap: 10px;
     align-items: flex-start;
-
-    .PollAnswer {
-      &-checkbox, &-text {
-        mix-blend-mode: darken;
-
-        & when (@config-dark-mode =true) {
-          mix-blend-mode: difference;
-        }
-      }
-    }
 
     .PollAnswer-checkbox {
       grid-column: 1;

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -243,18 +243,18 @@
       }
     }
 
-     .PollAnswer-text {
-         grid-column: ~"1 / span 2";
+    .PollAnswer-text {
+      grid-column: ~"1 / span 2";
       grid-row: 1;
 
-       display: flex;
-       column-gap: 5px;
-       align-items: first baseline;
+      display: flex;
+      column-gap: 5px;
+      align-items: first baseline;
 
-       &-answer {
-         flex-grow: 1;
-       }
-     }
+      &-answer {
+        flex-grow: 1;
+      }
+    }
 
     .PollAnswer-image {
       grid-column: ~"1 / span 2";
@@ -269,7 +269,10 @@
       right: 0;
       left: 0;
       z-index: -1;
-      background-image: linear-gradient(to right, var(--poll-option-color) 0% 100%);
+      background-image: linear-gradient(
+        to right,
+        var(--poll-option-color) 0% 100%
+      );
       background-size: var(--poll-option-width) 100%;
       background-repeat: no-repeat;
       content: '';
@@ -324,8 +327,6 @@
         border-width: 0 3px 3px 0;
         transform: rotate(45deg);
       }
-
-
     }
   }
 }

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -11,16 +11,16 @@
     font-weight: 600;
     display: inline-block;
     padding: 0.1em 0.5em;
-    border-radius: @border-radius;
-    background: @body-bg;
-    color: @control-color;
+    border-radius: var(--border-radius);
+    background: var(--body-bg);
+    color: var(--control-color);
     text-transform: none;
-    border: 1px solid @primary-color;
+    border: 1px solid var(--primary-color);
 
     &.none {
       background: transparent;
-      border: 1px dotted @muted-color;
-      color: @muted-color;
+      border: 1px dotted var(--muted-color);
+      color: var(--muted-color);
     }
   }
 }
@@ -131,13 +131,6 @@
         }
       }
     }
-
-    .PollAnswer-text::after {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      content: @fof-polls-options-color-blend ;
-    }
   }
 
   .Poll-sticky {
@@ -150,7 +143,7 @@
     align-items: flex-start;
     column-gap: 15px;
     background-color: var(--body-bg);
-    .box-shadow(inset 0px 2px 0px 0px fade(@text-color, 20%));
+    .box-shadow(inset 0px 2px 0px 0px var(--muted-more-bg));
 
     &:empty {
       display: none;
@@ -196,7 +189,7 @@
   }
 
   &:hover {
-    background: #f3f3f39e;
+    background: var(--muted-more-bg);
   }
 
   /* Percent */
@@ -206,7 +199,7 @@
     font-weight: 600;
 
     &--option {
-      color: @muted-color;
+      color: var(--muted-color);
     }
   }
 
@@ -216,8 +209,8 @@
     display: inline-block;
     padding: .1em .5em;
     border-radius: 4px;
-    background: #e8ecf3;
-    color: #667c99;
+    background: transparent;
+    color: var(--muted-color);
     text-transform: none;
   }
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,3 +1,8 @@
+:root {
+  --poll-option-color: var(--muted-color);
+  --poll-option-active-color: var(--secondary-color);
+}
+
 .ComposerBody-poll {
   margin-right: 15px;
 
@@ -121,7 +126,6 @@
     display: flex;
     align-items: flex-start;
     column-gap: 15px;
-    z-index: 999;
     background-color: var(--body-bg);
     .box-shadow(inset 0px 2px 0px 0px fade(@text-color, 20%));
 
@@ -164,29 +168,23 @@
 }
 
 .PollOption {
-  & &-active {
-    height: 100%;
-    left: 0;
-    position: absolute;
-    z-index: 1;
-    top: 0;
-    width: var(--width, 0);
-    background-color: @muted-color;
+  &, .PollBar {
+    border-radius: 4px;
+  }
 
-    // Don't animate if the post is hidden
-    &:not(.Post--hidden &) {
-      animation: slideIn 1s ease-in-out;
-      transition: width 0.75s ease-in-out;
-    }
-
-    .checkmark {
-      background-color: #fabc67;
-    }
+  &:hover {
+    background: #f3f3f39e;
   }
 
   /* Percent */
   .PollPercent {
     padding-right: 5px;
+    font-size: 11px;
+    font-weight: 600;
+
+    &--option {
+      color: @muted-color;
+    }
   }
 
   .PollLabel {
@@ -200,57 +198,90 @@
     text-transform: none;
   }
 
-  .PollAnswerImage {
-    display: block; // Put image on its own line below label text
-    max-width: 100%;
-    margin-top: 10px;
+  &:not(.Post--hidden &) {
+    .PollBar::after {
+      animation: slideInPollBackground 1s ease-in-out;
+      transition: background-size 0.75s ease-in-out;
+    }
   }
 
   .PollBar {
-    background: transparent;
     padding: 10px;
     position: relative;
-    border-radius: 4px;
-    border: 2px solid @muted-color;
+    border: 2px solid var(--poll-option-color);
     overflow: hidden;
+    isolation: isolate;
 
-    display: flex;
-    column-gap: 10px;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-auto-flow: row;
+    gap: 10px;
     align-items: flex-start;
 
-    &:hover {
-      background: #f3f3f39e;
-    }
+    .PollAnswer {
+      &-checkbox, &-text {
+        mix-blend-mode: darken;
 
-    label {
-      position: relative;
-      z-index: 2;
-
-      span {
-        font-size: 11px;
-        line-height: 19px;
-        font-weight: 600;
+        & when (@config-dark-mode =true) {
+          mix-blend-mode: difference;
+        }
       }
     }
+
+    .PollAnswer-checkbox {
+      grid-column: 1;
+      grid-row: 1;
+
+      + .PollAnswer-text {
+        grid-column: 2;
+      }
+    }
+
+     .PollAnswer-text {
+         grid-column: ~"1 / span 2";
+      grid-row: 1;
+
+       display: flex;
+       column-gap: 5px;
+       align-items: first baseline;
+
+       &-answer {
+         flex-grow: 1;
+       }
+     }
+
+    .PollAnswer-image {
+      grid-column: ~"1 / span 2";
+      grid-row: 2;
+      max-width: 100%;
+    }
+
+    &::after {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      left: 0;
+      z-index: -1;
+      background-image: linear-gradient(to right, var(--poll-option-color) 0% 100%);
+      background-size: var(--poll-option-width) 100%;
+      background-repeat: no-repeat;
+      content: '';
+    }
+
     .PollAnswer {
       flex-grow: 1;
     }
 
-    &[data-selected=true] {
-      border-color: @secondary-color;
-
-      .PollOption-active {
-        background-color: @secondary-color;
-      }
-
-      label .PollAnswer {
-        color: contrast(@secondary-color);
-      }
+    &[data-selected] {
+      --poll-option-color: var(--poll-option-active-color);
     }
   }
 
-  label.checkbox {
+  .PollAnswer-checkbox {
     margin-bottom: 0;
+    position: relative;
+    z-index: 2;
 
     input[type="checkbox"] {
       position: absolute;
@@ -283,10 +314,8 @@
         top: 3px;
         width: 5px;
         height: 10px;
-        border: solid black;
+        border: solid var(--text-color);
         border-width: 0 3px 3px 0;
-        -webkit-transform: rotate(45deg);
-        -ms-transform: rotate(45deg);
         transform: rotate(45deg);
       }
 
@@ -350,15 +379,11 @@
   }
 }
 
-@keyframes slideIn {
+@keyframes slideInPollBackground {
   from {
-    width: 0
+    background-size: 0 100%;
   }
   to {
-    width: var(--width);
+    background-size: var(--poll-option-width) 100%;
   }
-}
-
-.PollPercent--option {
-  color: #868686;
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -3,6 +3,8 @@ fof-polls:
     settings:
       allow_option_image: Allow an image URL to be provided for each poll option
       max_options: Maximum number of options per poll
+      options_color_blend: Color blend text in poll options
+      options_color_blend_help: Use this to use color mixing to make the poll options more readable. Disable if this feature causes issues with your forum's appearance, reducing readability.
     permissions:
       view_results_without_voting: View results without voting
       start: Start a poll


### PR DESCRIPTION

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Refs #15**

**Changes proposed in this pull request:**
- If voting checkbox input is not shown, show checkmark next to percent
- Reorganize DOM and use grid layout for general poll option
- Remove `PollOption` as an absolute bar, use `PollBar::after` pseudoelement
- Use `mix-blend-mode` for attempting to get readable text color
- Fix selector highlighting voted options

**Reviewers should focus on:**
It's hard to find settings that work well for all scenarios - probably impossible. I believe this is an improvement over the current state, though. Some scenarios have worse legibility, but this allows those that barely had any to have some.

Maybe a setting can be introduced to let forums decide whether they want to use `mix-blend-mode`? Since the effects mostly depend on the selected primary & secondary colors, it might be a good idea to let them turn it off if it works better without.

**Screenshot**
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/fce8e0e7-4a6b-4573-9311-a5a9c580a351)
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/5e92ac1d-5457-449c-91e6-9c22054c19f0)
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/488c6109-2657-4551-b1c6-97aa71d69b23)
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/f076d989-a65a-4db6-80c1-2274c4f9c6e3)
![image](https://github.com/FriendsOfFlarum/polls/assets/6401250/2decbaf6-7cf8-4233-a42c-8b04be6deb7d)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.