### PR TITLE
feat: show total vote count in the footer.

### DIFF
--- a/js/src/forum/components/PollView.tsx
+++ b/js/src/forum/components/PollView.tsx
@@ -175,7 +175,7 @@ export default class PollView extends Component<PollAttrs, PollState> {
       items.add(
         'max-votes',
         <span>
-          <i className="icon fas fa-chart-bar fa-fw" />
+          <i className="icon fas fa-poll fa-fw" />
           {app.translator.trans('fof-polls.forum.max_votes_allowed', { max: maxVotes })}
         </span>
       );
@@ -195,7 +195,7 @@ export default class PollView extends Component<PollAttrs, PollState> {
       items.add(
         'total-vote-count',
         <span>
-          <i className="icon fas fa-chart-bar fa-fw" aria-hidden="true" />
+          <i className="icon fas fa-poll fa-fw" aria-hidden="true" />
           {app.translator.trans('fof-polls.forum.poll.total_votes', { count: poll.voteCount() })}
         </span>
       );

--- a/js/src/forum/components/PollView.tsx
+++ b/js/src/forum/components/PollView.tsx
@@ -171,11 +171,11 @@ export default class PollView extends Component<PollAttrs, PollState> {
       );
     }
 
-    if (poll.canVote()) {
+    if (poll.canVote() && !poll.hasEnded() && !this.state.hasVoted()) {
       items.add(
         'max-votes',
         <span>
-          <i className="icon fas fa-poll fa-fw" />
+          <i className="icon fas fa-chart-bar fa-fw" />
           {app.translator.trans('fof-polls.forum.max_votes_allowed', { max: maxVotes })}
         </span>
       );
@@ -189,6 +189,16 @@ export default class PollView extends Component<PollAttrs, PollState> {
           </span>
         );
       }
+    }
+
+    if (poll.hasEnded() || this.state.hasVoted()) {
+      items.add(
+        'total-vote-count',
+        <span>
+          <i className="icon fas fa-chart-bar fa-fw" aria-hidden="true" />
+          {app.translator.trans('fof-polls.forum.poll.total_votes', { count: poll.voteCount() })}
+        </span>
+      );
     }
 
     return items;

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -46,6 +46,7 @@ fof-polls:
       submit_button: Vote
       start_poll_button: Start Global Poll
       cannot_start_poll_button: Cannot Start Poll
+      total_votes: "{count, plural, one {# vote was given} other {# votes were given}}"
 
     poll_controls:
       edit_label: => core.ref.edit


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
- Add total vote count in the footer of a global poll, once the user has voted or the poll has ended.
- Don't show max votes once the user has voted or the poll has ended, that information is no longer relevant.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/f2b2cb75-c6d4-4e52-9cc6-d8295dea22e6" />

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
