### PR TITLE
chore: add serializer checks

### DIFF
--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -33,7 +33,7 @@ class PollOptionSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($option)
     {
-        if (! ($option instanceof PollOption)) {
+        if (!($option instanceof PollOption)) {
             throw new InvalidArgumentException(
                 get_class($this).' can only serialize instances of '.PollOption::class
             );

--- a/src/Api/Serializers/PollOptionSerializer.php
+++ b/src/Api/Serializers/PollOptionSerializer.php
@@ -15,6 +15,7 @@ use Flarum\Api\Serializer\AbstractSerializer;
 use FoF\Polls\PollOption;
 use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
+use InvalidArgumentException;
 
 class PollOptionSerializer extends AbstractSerializer
 {
@@ -32,6 +33,12 @@ class PollOptionSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($option)
     {
+        if (! ($option instanceof PollOption)) {
+            throw new InvalidArgumentException(
+                get_class($this).' can only serialize instances of '.PollOption::class
+            );
+        }
+
         $attributes = [
             'answer'      => $option->answer,
             'imageUrl'    => $this->getImageUrl($option),

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -15,6 +15,7 @@ use Flarum\Api\Serializer\AbstractSerializer;
 use FoF\Polls\Poll;
 use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Contracts\Filesystem\Factory;
+use InvalidArgumentException;
 
 class PollSerializer extends AbstractSerializer
 {
@@ -32,6 +33,12 @@ class PollSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($poll)
     {
+        if (! ($poll instanceof Poll)) {
+            throw new InvalidArgumentException(
+                get_class($this).' can only serialize instances of '.Poll::class
+            );
+        }
+
         $canEdit = $this->actor->can('edit', $poll);
 
         $attributes = [

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -100,6 +100,10 @@ class PollSerializer extends AbstractSerializer
 
     public function myVotes($model)
     {
+        if (!($model instanceof Poll)) {
+            return null;
+        }
+
         Poll::setStateUser($this->actor);
 
         // When called inside ShowDiscussionController, Flarum has already pre-loaded our relationship incorrectly

--- a/src/Api/Serializers/PollSerializer.php
+++ b/src/Api/Serializers/PollSerializer.php
@@ -33,7 +33,7 @@ class PollSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($poll)
     {
-        if (! ($poll instanceof Poll)) {
+        if (!($poll instanceof Poll)) {
             throw new InvalidArgumentException(
                 get_class($this).' can only serialize instances of '.Poll::class
             );

--- a/src/Api/Serializers/PollVoteSerializer.php
+++ b/src/Api/Serializers/PollVoteSerializer.php
@@ -32,7 +32,7 @@ class PollVoteSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($vote)
     {
-        if (! ($vote instanceof PollVote)) {
+        if (!($vote instanceof PollVote)) {
             throw new InvalidArgumentException(
                 get_class($this).' can only serialize instances of '.PollVote::class
             );

--- a/src/Api/Serializers/PollVoteSerializer.php
+++ b/src/Api/Serializers/PollVoteSerializer.php
@@ -14,6 +14,7 @@ namespace FoF\Polls\Api\Serializers;
 use Flarum\Api\Serializer\AbstractSerializer;
 use Flarum\Api\Serializer\BasicUserSerializer;
 use FoF\Polls\PollVote;
+use InvalidArgumentException;
 
 class PollVoteSerializer extends AbstractSerializer
 {
@@ -31,6 +32,12 @@ class PollVoteSerializer extends AbstractSerializer
      */
     protected function getDefaultAttributes($vote)
     {
+        if (! ($vote instanceof PollVote)) {
+            throw new InvalidArgumentException(
+                get_class($this).' can only serialize instances of '.PollVote::class
+            );
+        }
+
         return [
             'pollId'    => $vote->poll_id,
             'optionId'  => $vote->option_id,


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
* Add basic serializer checks 
* Return null in myVotes method if the model is not an instance of `Poll`. This is a workaround because of line 110 in `PollSerializer` where we unset the relation. I'm not too comfortable removing that line and debugging if that could be made in another way which doesn't have side effects

https://github.com/FriendsOfFlarum/polls/blob/ca33d7fc9e953d1f2b217801daec58012033f73c/src/Api/Serializers/PollSerializer.php#L110

**Reviewers should focus on:**
Please test this locally

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
