### PR TITLE
feat: add loading indicator to PollShowcase while loading state

### DIFF
--- a/js/src/forum/components/PollShowcase.tsx
+++ b/js/src/forum/components/PollShowcase.tsx
@@ -39,7 +39,7 @@ export default class PollShowcase extends Component<PollListAttrs, PollListState
     const items = new ItemList<Mithril.Children>();
 
     // Show loading indicator while the state is loading
-    this.attrs.state.isLoading() && items.add('loading', <LoadingIndicator />);
+    this.attrs.state.isLoading() && items.add('loading', <LoadingIndicator size="large" />);
 
     this.attrs.state.getPages().map((page) => {
       page.items.map((poll) => {
@@ -56,7 +56,7 @@ export default class PollShowcase extends Component<PollListAttrs, PollListState
     const items = new ItemList<Mithril.Children>();
 
     // Show loading indicator while the state is loading
-    this.attrs.state.isLoading() && items.add('loading', <LoadingIndicator />);
+    this.attrs.state.isLoading() && items.add('loading', <LoadingIndicator size="large" />);
 
     this.attrs.state.getPages().map((page) => {
       page.items.map((poll) => {


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Add loading indicators to the showcase page while the state is loading. Currently, a placeholder is shown during loading, which is misleading because it gives the impression that no poll exists, when in fact the data is still being fetched.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
