### PR TITLE
fix: improve poll settings

### DIFF
--- a/js/src/forum/components/PollForm.tsx
+++ b/js/src/forum/components/PollForm.tsx
@@ -193,13 +193,9 @@ export default class PollForm extends Component<PollFormAttrs, PollFormState> {
     items.add(
       'public',
       <div className="Form-group">
-        {Switch.component(
-          {
-            state: this.publicPoll() || false,
-            onchange: this.publicPoll,
-          },
-          app.translator.trans('fof-polls.forum.modal.public_poll_label')
-        )}
+        <Switch state={this.publicPoll() || false} onchange={this.publicPoll} disabled={this.hideVotes()}>
+          {app.translator.trans('fof-polls.forum.modal.public_poll_label')}
+        </Switch>
       </div>,
       20
     );
@@ -207,7 +203,7 @@ export default class PollForm extends Component<PollFormAttrs, PollFormState> {
     items.add(
       'hide-votes',
       <div className="Form-group">
-        <Switch state={this.endDate() && this.hideVotes()} onchange={this.hideVotes} disabled={!this.endDate()}>
+        <Switch state={this.endDate() && this.hideVotes()} onchange={this.hideVotes} disabled={!this.endDate() || this.publicPoll()}>
           {app.translator.trans('fof-polls.forum.modal.hide_votes_label')}
         </Switch>
         <p className="helpText">{app.translator.trans('fof-polls.forum.modal.hide_votes_label_help')}</p>

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -92,12 +92,12 @@ fof-polls:
       option_placeholder: Answer
       image_option_placeholder: Image URL (optional)
       options_label: Answers
-      public_poll_label: Allow people to see who voted
+      public_poll_label: Allow everyone to see who voted
       allow_multiple_votes_label: Allow people to vote for multiple options
       max_votes_label: Max votes per user
       max_votes_help: Set to 0 to allow users to vote for all options.
-      hide_votes_label: Hide votes until poll ends
-      hide_votes_label_help: The user who started the poll will always be able to see the votes.
+      hide_votes_label: Hide poll results until poll ends
+      hide_votes_label_help: The user who started the poll will always be able to see the poll results. It requires a poll end date.
       allow_change_vote_label: Allow users to change their vote
       question_placeholder: Question
       subtitle_placeholder: Subtitle/Description (optional)

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -21,12 +21,13 @@ class PollPolicy extends AbstractPolicy
     public function seeVoteCount(User $actor, Poll $poll)
     {
         $isPollAuthor = $actor->id === $poll->user_id;
+        $isAdmin = $actor->isAdmin();
 
-        if ($poll->hide_votes && $poll->end_date && !$poll->hasEnded() && !$isPollAuthor) {
+        if ($poll->hide_votes && $poll->end_date && !$poll->hasEnded() && !$isPollAuthor && !$isAdmin) {
             return $this->deny();
         }
 
-        if ($poll->myVotes($actor)->count() || $actor->can('polls.viewResultsWithoutVoting', $poll->post !== null ? $poll->post->discussion : null) || $poll->isGlobal() || $isPollAuthor) {
+        if ($poll->myVotes($actor)->count() || $actor->can('polls.viewResultsWithoutVoting', $poll->post !== null ? $poll->post->discussion : null) || $poll->isGlobal() || $isPollAuthor || $isAdmin) {
             return $this->allow();
         }
     }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Improve poll setting UX and always allow admins to see vote counts and voters

**Changes proposed in this pull request:**
- Reflect mutually exclusive public poll and hide votes settings in UI by disabling the other setting when one is enabled
- Improve clarity of public poll and hide votes setting labels in UI
- Include admin check in vote count visibility logic. Always allow admins to see the vote result and list of voters 

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="565" height="227" alt="image" src="https://github.com/user-attachments/assets/efbd0e0e-20fd-465a-982a-cd471ec47685" />
<img width="562" height="224" alt="image" src="https://github.com/user-attachments/assets/6522d9ac-7a45-405b-bb7a-51fa42618050" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
