### PR TITLE
fix: correct PollIsEndedFilter logic and showcase page poll display

### DIFF
--- a/js/src/forum/components/Poll/PollShowcase.tsx
+++ b/js/src/forum/components/Poll/PollShowcase.tsx
@@ -39,11 +39,7 @@ export default class PollShowcase extends Component<PollListAttrs, PollListState
             <Placeholder text={app.translator.trans('fof-polls.forum.showcase.no-recent-polls')} />
           )}
           {this.attrs.endedState.hasNext() && (
-            <Button
-              className="Button"
-              loading={this.attrs.endedState.isLoadingNext()}
-              onclick={() => this.attrs.endedState.loadNext()}
-            >
+            <Button className="Button" loading={this.attrs.endedState.isLoadingNext()} onclick={() => this.attrs.endedState.loadNext()}>
               {app.translator.trans('core.forum.discussion_list.load_more_button')}
             </Button>
           )}

--- a/js/src/forum/components/Poll/PollShowcase.tsx
+++ b/js/src/forum/components/Poll/PollShowcase.tsx
@@ -6,30 +6,47 @@ import PollShowcaseItem from './PollShowcaseItem';
 import Placeholder from 'flarum/common/components/Placeholder';
 import app from 'flarum/forum/app';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
+import Button from 'flarum/common/components/Button';
 
 export interface PollListAttrs extends ComponentAttrs {
-  state: PollListState;
+  activeState: PollListState;
+  endedState: PollListState;
 }
 
 export default class PollShowcase extends Component<PollListAttrs, PollListState> {
   oninit(vnode: Mithril.Vnode) {
     super.oninit(vnode);
-
-    this.attrs.state.refresh();
+    // States are already refreshed by PollsShowcasePage.
   }
 
   view(): Mithril.Children {
+    const activeItems = this.showcaseItems();
+    const endedItems = this.endedItems();
+
     return (
       <div className="PollShowcase">
         <div className="PollShowcase--active">
           <h2 className="PollShowcase-title PollShowcase-title--active">{app.translator.trans('fof-polls.forum.showcase.active-polls')}</h2>
-          {this.showcaseItems().toArray()}
-          {this.showcaseItems().toArray().length === 0 && <Placeholder text={app.translator.trans('fof-polls.forum.showcase.no-active-polls')} />}
+          {activeItems.toArray()}
+          {!this.attrs.activeState.isLoading() && activeItems.toArray().length === 0 && (
+            <Placeholder text={app.translator.trans('fof-polls.forum.showcase.no-active-polls')} />
+          )}
         </div>
         <div className="PollShowcase--ended">
           <h2 className="PollShowcase-title PollShowcase-title--ended">{app.translator.trans('fof-polls.forum.showcase.ended-polls')}</h2>
-          {this.endedItems().toArray()}
-          {this.endedItems().toArray().length === 0 && <Placeholder text={app.translator.trans('fof-polls.forum.showcase.no-recent-polls')} />}
+          {endedItems.toArray()}
+          {!this.attrs.endedState.isLoading() && endedItems.toArray().length === 0 && (
+            <Placeholder text={app.translator.trans('fof-polls.forum.showcase.no-recent-polls')} />
+          )}
+          {this.attrs.endedState.hasNext() && (
+            <Button
+              className="Button"
+              loading={this.attrs.endedState.isLoadingNext()}
+              onclick={() => this.attrs.endedState.loadNext()}
+            >
+              {app.translator.trans('core.forum.discussion_list.load_more_button')}
+            </Button>
+          )}
         </div>
       </div>
     );
@@ -38,14 +55,14 @@ export default class PollShowcase extends Component<PollListAttrs, PollListState
   showcaseItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
-    // Show loading indicator while the state is loading
-    this.attrs.state.isLoading() && items.add('loading', <LoadingIndicator size="large" />);
+    if (this.attrs.activeState.isLoading()) {
+      items.add('loading', <LoadingIndicator size="large" />);
+      return items;
+    }
 
-    this.attrs.state.getPages().map((page) => {
-      page.items.map((poll) => {
-        if (!poll.hasEnded()) {
-          items.add('poll-active-' + poll.id(), <PollShowcaseItem poll={poll} />);
-        }
+    this.attrs.activeState.getPages().forEach((page) => {
+      page.items.forEach((poll) => {
+        items.add('poll-active-' + poll.id(), <PollShowcaseItem poll={poll} />);
       });
     });
 
@@ -55,14 +72,14 @@ export default class PollShowcase extends Component<PollListAttrs, PollListState
   endedItems(): ItemList<Mithril.Children> {
     const items = new ItemList<Mithril.Children>();
 
-    // Show loading indicator while the state is loading
-    this.attrs.state.isLoading() && items.add('loading', <LoadingIndicator size="large" />);
+    if (this.attrs.endedState.isLoading()) {
+      items.add('loading', <LoadingIndicator size="large" />);
+      return items;
+    }
 
-    this.attrs.state.getPages().map((page) => {
-      page.items.map((poll) => {
-        if (poll.hasEnded()) {
-          items.add('poll-ended-' + poll.id(), <PollShowcaseItem poll={poll} />);
-        }
+    this.attrs.endedState.getPages().forEach((page) => {
+      page.items.forEach((poll) => {
+        items.add('poll-ended-' + poll.id(), <PollShowcaseItem poll={poll} />);
       });
     });
 

--- a/js/src/forum/components/PollsShowcasePage.tsx
+++ b/js/src/forum/components/PollsShowcasePage.tsx
@@ -10,6 +10,8 @@ import { AbstractPollPage } from './AbstractPollPage';
 import PollShowcase from './Poll/PollShowcase';
 
 export default class PollsShowcasePage extends AbstractPollPage {
+  endedState!: PollListState;
+
   oninit(vnode: Mithril.Vnode<IPageAttrs, PollListState>) {
     super.oninit(vnode);
 
@@ -20,11 +22,18 @@ export default class PollsShowcasePage extends AbstractPollPage {
 
     this.state = new PollListState({
       sort: m.route.param('sort'),
-      filter: m.route.param('filter'),
+      filter: { '-isEnded': '1' },
+      include: this.includeParams(),
+    });
+
+    this.endedState = new PollListState({
+      sort: m.route.param('sort'),
+      filter: { isEnded: '1' },
       include: this.includeParams(),
     });
 
     this.state.refresh();
+    this.endedState.refresh();
 
     app.setTitle(extractText(app.translator.trans('fof-polls.forum.page.nav')));
   }
@@ -37,7 +46,7 @@ export default class PollsShowcasePage extends AbstractPollPage {
     const items = super.contentItems();
 
     if (!this.loading) {
-      items.add('poll-showcase', <PollShowcase state={this.state} />);
+      items.add('poll-showcase', <PollShowcase activeState={this.state} endedState={this.endedState} />);
     }
 
     return items;

--- a/src/Filter/PollIsEndedFilter.php
+++ b/src/Filter/PollIsEndedFilter.php
@@ -25,9 +25,16 @@ class PollIsEndedFilter implements FilterInterface
     public function filter(FilterState $filterState, string $filterValue, bool $negate)
     {
         if ($negate) {
-            return $filterState->getQuery()->whereNull('end_date')->orWhere('end_date', '<=', Carbon::now());
+            // filter[-isEnded]=1 → active polls (not ended)
+            $filterState->getQuery()->where(function ($query) {
+                $query->whereNull('end_date')
+                      ->orWhere('end_date', '>', Carbon::now());
+            });
+        } else {
+            // filter[isEnded]=1 → ended polls
+            $filterState->getQuery()
+                ->whereNotNull('end_date')
+                ->where('end_date', '<=', Carbon::now());
         }
-
-        return $filterState->getQuery()->where('end_date', '>', Carbon::now());
     }
 }

--- a/tests/integration/api/AbstractPollGroupTestCase.php
+++ b/tests/integration/api/AbstractPollGroupTestCase.php
@@ -74,6 +74,6 @@ abstract class AbstractPollGroupTestCase extends TestCase
 
     protected function getDefaultPoll(): array
     {
-        return ['id' => 1, 'question' => 'Test Poll', 'poll_group_id' => 1, 'user_id' => 1];
+        return ['id' => 1, 'question' => 'Test Poll', 'poll_group_id' => 1, 'user_id' => 1, 'settings' => '{}'];
     }
 }

--- a/tests/integration/api/ListGlobalPollsTest.php
+++ b/tests/integration/api/ListGlobalPollsTest.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Polls\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class ListGlobalPollsTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-polls');
+
+        $this->setting('fof-polls.enableGlobalPolls', true);
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+            ],
+            'polls' => [
+                // Poll 1: Active — no end date (perpetual)
+                ['id' => 1, 'question' => 'Active poll no end', 'subtitle' => null, 'image' => null, 'image_alt' => null, 'post_id' => null, 'user_id' => 1, 'public_poll' => 0, 'end_date' => null, 'created_at' => '2025-01-01 00:00:00', 'updated_at' => '2025-01-01 00:00:00', 'vote_count' => 0, 'allow_multiple_votes' => 0, 'max_votes' => 0, 'settings' => '{"max_votes": 0,"hide_votes": false,"public_poll": false,"allow_change_vote": false,"allow_multiple_votes": false}'],
+                // Poll 2: Active — end date in the future
+                ['id' => 2, 'question' => 'Active poll future end', 'subtitle' => null, 'image' => null, 'image_alt' => null, 'post_id' => null, 'user_id' => 1, 'public_poll' => 0, 'end_date' => '2030-01-01 00:00:00', 'created_at' => '2025-01-02 00:00:00', 'updated_at' => '2025-01-02 00:00:00', 'vote_count' => 0, 'allow_multiple_votes' => 0, 'max_votes' => 0, 'settings' => '{"max_votes": 0,"hide_votes": false,"public_poll": false,"allow_change_vote": false,"allow_multiple_votes": false}'],
+                // Poll 3: Ended — end date in the past
+                ['id' => 3, 'question' => 'Ended poll old', 'subtitle' => null, 'image' => null, 'image_alt' => null, 'post_id' => null, 'user_id' => 1, 'public_poll' => 0, 'end_date' => '2020-01-01 00:00:00', 'created_at' => '2025-01-03 00:00:00', 'updated_at' => '2025-01-03 00:00:00', 'vote_count' => 0, 'allow_multiple_votes' => 0, 'max_votes' => 0, 'settings' => '{"max_votes": 0,"hide_votes": false,"public_poll": false,"allow_change_vote": false,"allow_multiple_votes": false}'],
+                // Poll 4: Ended — end date in the past (more recent)
+                ['id' => 4, 'question' => 'Ended poll recent', 'subtitle' => null, 'image' => null, 'image_alt' => null, 'post_id' => null, 'user_id' => 1, 'public_poll' => 0, 'end_date' => '2021-06-01 00:00:00', 'created_at' => '2025-01-04 00:00:00', 'updated_at' => '2025-01-04 00:00:00', 'vote_count' => 0, 'allow_multiple_votes' => 0, 'max_votes' => 0, 'settings' => '{"max_votes": 0,"hide_votes": false,"public_poll": false,"allow_change_vote": false,"allow_multiple_votes": false}'],
+            ],
+            'poll_options' => [
+                ['id' => 1, 'answer' => 'Yes', 'poll_id' => 1, 'vote_count' => 0, 'created_at' => '2025-01-01 00:00:00', 'updated_at' => '2025-01-01 00:00:00'],
+                ['id' => 2, 'answer' => 'No', 'poll_id' => 1, 'vote_count' => 0, 'created_at' => '2025-01-01 00:00:00', 'updated_at' => '2025-01-01 00:00:00'],
+                ['id' => 3, 'answer' => 'Yes', 'poll_id' => 2, 'vote_count' => 0, 'created_at' => '2025-01-02 00:00:00', 'updated_at' => '2025-01-02 00:00:00'],
+                ['id' => 4, 'answer' => 'No', 'poll_id' => 2, 'vote_count' => 0, 'created_at' => '2025-01-02 00:00:00', 'updated_at' => '2025-01-02 00:00:00'],
+                ['id' => 5, 'answer' => 'Yes', 'poll_id' => 3, 'vote_count' => 0, 'created_at' => '2025-01-03 00:00:00', 'updated_at' => '2025-01-03 00:00:00'],
+                ['id' => 6, 'answer' => 'No', 'poll_id' => 3, 'vote_count' => 0, 'created_at' => '2025-01-03 00:00:00', 'updated_at' => '2025-01-03 00:00:00'],
+                ['id' => 7, 'answer' => 'Yes', 'poll_id' => 4, 'vote_count' => 0, 'created_at' => '2025-01-04 00:00:00', 'updated_at' => '2025-01-04 00:00:00'],
+                ['id' => 8, 'answer' => 'No', 'poll_id' => 4, 'vote_count' => 0, 'created_at' => '2025-01-04 00:00:00', 'updated_at' => '2025-01-04 00:00:00'],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function can_list_all_global_polls()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/polls', [
+                'authenticatedAs' => 1,
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $this->assertCount(4, $data);
+    }
+
+    /**
+     * @test
+     */
+    public function can_filter_ended_polls()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/polls', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams(['filter' => ['isEnded' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $this->assertCount(2, $data);
+
+        $ids = array_column($data, 'id');
+        $this->assertContains('3', $ids);
+        $this->assertContains('4', $ids);
+
+        foreach ($data as $poll) {
+            $this->assertTrue($poll['attributes']['hasEnded']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_filter_active_polls()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/polls', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams(['filter' => ['-isEnded' => '1']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $this->assertCount(2, $data);
+
+        $ids = array_column($data, 'id');
+        $this->assertContains('1', $ids);
+        $this->assertContains('2', $ids);
+
+        foreach ($data as $poll) {
+            $this->assertFalse($poll['attributes']['hasEnded']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function active_filter_includes_null_end_date()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/polls', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams(['filter' => ['-isEnded' => '1']])
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $ids = array_column($data, 'id');
+        $this->assertContains('1', $ids, 'Poll with null end_date should appear in active filter');
+
+        $poll1 = collect($data)->firstWhere('id', '1');
+        $this->assertNull($poll1['attributes']['endDate']);
+    }
+
+    /**
+     * @test
+     */
+    public function active_filter_includes_future_end_date()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/polls', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams(['filter' => ['-isEnded' => '1']])
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $ids = array_column($data, 'id');
+        $this->assertContains('2', $ids, 'Poll with future end_date should appear in active filter');
+
+        $poll2 = collect($data)->firstWhere('id', '2');
+        $this->assertNotNull($poll2['attributes']['endDate']);
+        $this->assertFalse($poll2['attributes']['hasEnded']);
+    }
+
+    /**
+     * @test
+     */
+    public function ended_filter_excludes_null_end_date()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/fof/polls', [
+                'authenticatedAs' => 1,
+            ])->withQueryParams(['filter' => ['isEnded' => '1']])
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $ids = array_column($data, 'id');
+        $this->assertNotContains('1', $ids, 'Poll with null end_date should NOT appear in ended filter');
+        $this->assertNotContains('2', $ids, 'Poll with future end_date should NOT appear in ended filter');
+    }
+}


### PR DESCRIPTION
### Summary

- Fix inverted `negate`/non-negate branches in `PollIsEndedFilter`, and scope the `orWhereNull` inside a closure to prevent query leakage
- Split the showcase page into two separate API requests (`filter[-isEnded]=1` for active, `filter[isEnded]=1` for ended) instead of fetching a single combined list capped at 20 and filtering client-side
- Add integration tests for the `GET /api/fof/polls` endpoint covering the `isEnded` filter
- Fix missing `settings` column in `DeletePollGroupTest` fixture data

### Problem

The polls showcase page (`/polls`) was not displaying all active polls. Two bugs contributed:

1. **`PollIsEndedFilter`** had its `$negate` branches swapped — `filter[isEnded]=1` returned active polls and `filter[-isEnded]=1` returned ended polls. Additionally, `orWhereNull('end_date')` was not wrapped in a closure, causing it to match unrelated rows.

2. **`PollsShowcasePage`** fetched a single unfiltered list of all polls (hardcoded page size of 20), then split them client-side using `hasEnded()`. When more than 20 total polls existed, active polls beyond position 20 were silently dropped.

### Changes

| File | Change |
|------|--------|
| `src/Filter/PollIsEndedFilter.php` | Swap negate branches; scope `orWhereNull` in closure |
| `js/src/forum/components/PollsShowcasePage.tsx` | Two `PollListState` instances with server-side filters |
| `js/src/forum/components/Poll/PollShowcase.tsx` | Accept separate `activeState`/`endedState`; add Load More for ended polls |
| `tests/integration/api/ListGlobalPollsTest.php` | 6 new integration tests for `isEnded` filter |
| `tests/integration/api/AbstractPollGroupTestCase.php` | Add `settings` column to poll fixture |

### Test plan

- [x] All 55 integration tests pass (including 6 new + 3 previously broken)
- [x] Manual verification: `/polls` page shows all active polls in "Active" section and all ended polls in "Ended" section
- [x] Verify two separate API requests in browser devtools (`filter[-isEnded]=1` and `filter[isEnded]=1`)