### PR TITLE
fix(polls): create poll-image subdirectories as public (0755), not private (0700)

### DIFF
--- a/src/PollImageDisk.php
+++ b/src/PollImageDisk.php
@@ -19,8 +19,9 @@ class PollImageDisk
     public function __invoke(Paths $paths, UrlGenerator $url): array
     {
         return [
-            'root'   => "$paths->public/assets/polls",
-            'url'    => $url->to('forum')->path('assets/polls'),
+            'root'       => "$paths->public/assets/polls",
+            'url'        => $url->to('forum')->path('assets/polls'),
+            'visibility' => 'public',
         ];
     }
 }


### PR DESCRIPTION
## Summary

Fixes #123. Daily upload folders under `public/assets/polls` (e.g. `2026-04-30/`) were being created with mode 0700 instead of 0755, so the web server could not serve poll images out of them even though the image files themselves were written 0644.

## Root cause

`PollImageDisk` returns the local-disk config without specifying a visibility:

```php
return [
    'root' => "$paths->public/assets/polls",
    'url'  => $url->to('forum')->path('assets/polls'),
];
```

Flarum's `FilesystemManager` (extending Laravel's) calls `createLocalDriver($config)`, which builds Flysystem v3's `PortableVisibilityConverter` from `$config['directory_visibility'] ?? $config['visibility'] ?? Visibility::PRIVATE`. With no key set, it falls back to **PRIVATE**, which maps to **0700** for new directories.

This matches the v1.x → v2.x regression in the issue: v1 used flysystem-1 where directory visibility was effectively 0755, and the upgrade to flysystem-3 silently changed the default.

## Fix

Add `'visibility' => 'public'` to the disk config so the converter uses **PUBLIC** (0755) as the default for new directories. File-level visibility (0644) is unchanged.

## Test plan

- [x] `php -l src/PollImageDisk.php` passes
- [ ] Manual: upload a poll image on a fresh forum, confirm the new `YYYY-MM-DD` folder under `public/assets/polls` is 0755 and the image renders without a chmod

Sister PR for the matching `fof/upload` issue: https://github.com/FriendsOfFlarum/upload/pull/489