### PR TITLE
perf: don't default-include firstPost.polls on the discussion list

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -155,24 +155,25 @@ return [
                             }),
                     ])
                     ->endpoint('index', function ($endpoint) {
+                        // Powers the `hasPoll` badge for every discussion on the list with a
+                        // single batched query, instead of a per-discussion `exists()`
+                        // (issue #124).
+                        //
+                        // We deliberately do NOT `addDefaultInclude('firstPost.polls')` here.
+                        // The discussion list only renders the boolean `hasPoll` badge (see
+                        // the frontend's addDiscussionBadge); poll bodies are rendered on the
+                        // `show` endpoint, which default-includes them. Serializing
+                        // `firstPost.polls` on every list page would ship — and load — poll
+                        // data the list UI never reads.
+                        //
+                        // Poll visibility is still enforced: the list only contains
+                        // discussions (and first posts) the actor can already see, and
+                        // discussion-scoped polls inherit that post's visibility (see
+                        // Access\ScopePollVisibility).
                         return $endpoint
-                            // Batch-load the first post's polls for every discussion in the
-                            // page in a single query. Without this, serializing the
-                            // `firstPost.polls` include resolves the relation one post at a
-                            // time, producing an N+1 on the discussion list (issue #124).
-                            // Poll visibility is still enforced: the discussion list only
-                            // contains discussions (and therefore first posts) the actor can
-                            // already see, and discussion-scoped polls inherit that post's
-                            // visibility (see Access\ScopePollVisibility).
-                            ->eagerLoadWhere('firstPost.polls', function ($query) {
-                                $query->select(['id', 'post_id']);
-                            })
-                            // Powers the `hasPoll` attribute without a per-discussion
-                            // `exists()` query.
                             ->eagerLoadWhere('polls', function ($query) {
                                 $query->select(['id', 'post_id']);
-                            })
-                            ->addDefaultInclude(['firstPost.polls']);
+                            });
                     })
                     ->endpoint('show', function ($endpoint) {
                         return $endpoint->addDefaultInclude([

--- a/tests/integration/api/ListDiscussionsPollsQueryCountTest.php
+++ b/tests/integration/api/ListDiscussionsPollsQueryCountTest.php
@@ -23,11 +23,14 @@ use PHPUnit\Framework\Attributes\Test;
  * Regression test for the N+1 polls queries on the discussion list described in
  * https://github.com/FriendsOfFlarum/polls/issues/124.
  *
- * The discussion index serializes `firstPost.polls`. Before the fix each
- * discussion's first-post polls were resolved with an individual query, so the
- * query count grew linearly with the number of discussions in the payload.
- * After the fix the polls must be resolved in a single batched query (or none
- * at all when the include is not requested).
+ * Powering the `hasPoll` badge previously fell back to a per-discussion
+ * `exists()` query, so the query count grew linearly with the number of
+ * discussions in the payload. It must instead be satisfied by a single batched
+ * eager-load of the polls relation.
+ *
+ * This fork additionally does not default-include `firstPost.polls` on the list
+ * (the list renders only the boolean badge), so the poll bodies must not be
+ * serialized into the discussion-list payload.
  */
 class ListDiscussionsPollsQueryCountTest extends TestCase
 {
@@ -187,25 +190,23 @@ class ListDiscussionsPollsQueryCountTest extends TestCase
     }
 
     #[Test]
-    public function discussion_list_still_includes_first_post_polls()
+    public function discussion_list_does_not_over_include_first_post_polls()
     {
         $data = $this->listDiscussions();
 
-        $included = $data['included'] ?? [];
+        $includedPolls = array_values(array_filter(
+            $data['included'] ?? [],
+            fn ($resource) => $resource['type'] === 'polls'
+        ));
 
-        $includedPollIds = array_column(
-            array_values(array_filter($included, fn ($resource) => $resource['type'] === 'polls')),
-            'id'
+        // The discussion list renders only the boolean `hasPoll` badge, never the
+        // poll bodies, so `firstPost.polls` is intentionally NOT default-included
+        // here (poll data is default-included on the `show` endpoint instead).
+        // Serializing every first post's polls onto the list is wasted payload and
+        // load — guard against it silently coming back.
+        $this->assertEmpty(
+            $includedPolls,
+            'The discussion list must not default-include firstPost.polls; the list only needs the hasPoll attribute.'
         );
-
-        // The batched eager-load must not drop the include — every fixture poll
-        // (ids 200..207) should still be serialized on the discussion list.
-        for ($i = 0; $i < self::DISCUSSION_COUNT; $i++) {
-            $this->assertContains(
-                (string) (200 + $i),
-                $includedPollIds,
-                'Poll '.(200 + $i).' should be included on the discussion list.'
-            );
-        }
     }
 }


### PR DESCRIPTION
### Follow-up to #130

#130 fixed the `firstPost.polls` N+1 on the discussion index, but kept the default include that causes the load in the first place:

```php
->eagerLoadWhere('firstPost.polls', ...)
->eagerLoadWhere('polls', ...)
->addDefaultInclude(['firstPost.polls']);
```

So every discussion-list page still batch-loads and serializes the poll bodies of every discussion's first post.

### Why they aren't needed on the list

The discussion list renders only the boolean `hasPoll` badge — `addDiscussionBadge.tsx` reads `this.hasPoll()` and nothing else. Poll bodies render from `post.polls()` in `addPollsToPost.tsx`, which is the **show** endpoint, and that already default-includes `firstPost.polls`, `.options`, `.myVotes` and `.myVotes.option`. No list component reads the serialized include.

As #130's own commit message notes, 2.3.x used `addOptionalInclude` and never default-loaded this — so the default include is itself the regression.

### Change

Drop `addDefaultInclude(['firstPost.polls'])` and the now-redundant `eagerLoadWhere('firstPost.polls', ...)` (nothing reads that relation once the include is gone). What remains is the single batched `eagerLoadWhere('polls', ...)` that powers `hasPoll` without a per-discussion `exists()` — so the #124 fix is fully preserved.

Result on a list page: one poll query instead of one plus a batched body load, and the poll payload drops out of the response entirely.

Visibility is unchanged — the list only contains discussions (and first posts) the actor can already see, and discussion-scoped polls inherit that post's visibility via `Access\ScopePollVisibility`.

### Tests

`ListDiscussionsPollsQueryCountTest` keeps its query-count and `hasPoll` assertions. Its third test asserted the include was present, so it's inverted to assert the poll bodies are *not* serialized onto the list — guarding against the over-include silently returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)