### PR TITLE
fix: keep maxVotes when creating a poll

### DIFF
--- a/src/Poll.php
+++ b/src/Poll.php
@@ -90,7 +90,7 @@ class Poll extends AbstractModel
         $poll->settings = [
             'public_poll'          => $publicPoll,
             'allow_multiple_votes' => $allowMultipleVotes,
-            'max_votes'            => min(0, (int) $maxVotes),
+            'max_votes'            => max(0, (int) $maxVotes),
             'hide_votes'           => $hideVotes,
             'allow_change_vote'    => $allowChangeVote,
         ];

--- a/tests/integration/api/CreatePollTest.php
+++ b/tests/integration/api/CreatePollTest.php
@@ -842,4 +842,109 @@ class CreatePollTest extends TestCase
 
         $this->assertEquals(404, $response->getStatusCode());
     }
+
+    #[Test]
+    public function max_votes_is_persisted_when_creating_a_poll()
+    {
+        $response = $this->send(
+            $this->request(
+                'POST',
+                '/api/posts',
+                [
+                    'authenticatedAs' => 1,
+                    'json'            => [
+                        'data' => [
+                            'attributes' => [
+                                'content' => 'Here is my poll',
+                                'poll'    => [
+                                    'question'           => 'Pick up to two colours',
+                                    'publicPoll'         => false,
+                                    'hideVotes'          => false,
+                                    'allowChangeVote'    => true,
+                                    'allowMultipleVotes' => true,
+                                    'maxVotes'           => 2,
+                                    'endDate'            => false,
+                                    'options'            => [
+                                        ['answer' => 'Red'],
+                                        ['answer' => 'Blue'],
+                                        ['answer' => 'Yellow'],
+                                    ],
+                                ],
+                            ],
+                            'relationships' => [
+                                'discussion' => [
+                                    'data' => [
+                                        'type' => 'discussions',
+                                        'id'   => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $pollId = $json['data']['relationships']['polls']['data'][0]['id'];
+
+        $poll = Poll::find($pollId);
+
+        // A positive maxVotes must survive creation. Clamping it with min(0, ...)
+        // instead of max(0, ...) silently stored 0, which means "unlimited"
+        // downstream (MultipleVotesPollHandler falls back to the option count),
+        // so the author's vote limit was dropped until the poll was edited.
+        $this->assertEquals(2, $poll->max_votes);
+    }
+
+    #[Test]
+    public function negative_max_votes_is_floored_to_zero_when_creating_a_poll()
+    {
+        $response = $this->send(
+            $this->request(
+                'POST',
+                '/api/posts',
+                [
+                    'authenticatedAs' => 1,
+                    'json'            => [
+                        'data' => [
+                            'attributes' => [
+                                'content' => 'Here is my poll',
+                                'poll'    => [
+                                    'question'           => 'What is your favourite colour?',
+                                    'publicPoll'         => false,
+                                    'hideVotes'          => false,
+                                    'allowChangeVote'    => true,
+                                    'allowMultipleVotes' => true,
+                                    'maxVotes'           => -5,
+                                    'endDate'            => false,
+                                    'options'            => [
+                                        ['answer' => 'Red'],
+                                        ['answer' => 'Blue'],
+                                    ],
+                                ],
+                            ],
+                            'relationships' => [
+                                'discussion' => [
+                                    'data' => [
+                                        'type' => 'discussions',
+                                        'id'   => 1,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        );
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $json = json_decode($response->getBody()->getContents(), true);
+        $pollId = $json['data']['relationships']['polls']['data'][0]['id'];
+
+        $this->assertEquals(0, Poll::find($pollId)->max_votes);
+    }
 }


### PR DESCRIPTION
### Problem

`Poll::build()` clamps the incoming vote limit with `min(0, (int) $maxVotes)`, which returns **0 for every positive input**. A poll created with a vote limit therefore always stores `max_votes = 0`.

Downstream, `0` means *unlimited* — `MultipleVotesPollHandler` falls back to the option count, as does the frontend's `PollState`. So the author's limit is silently dropped and voters can pick every option, until someone edits the poll.

The edit path already clamps correctly:

```php
// EditPollHandler.php
$poll->settings['max_votes'] = min(max($maxVotes, 0), $options->count());
```

which is the intended behaviour — only creation was affected.

### Fix

`max(0, ...)` instead of `min(0, ...)`, so positive limits survive and negatives still floor to 0.

The option-count ceiling isn't applied here because options are created after the poll is saved (`CreatePollHandler` builds and saves the poll, then inserts options). The edit path and the frontend's `max={this.options.length}` input already enforce it, and voting can't exceed the number of options that exist anyway.

### Tests

Added regression coverage for the positive and negative cases. Worth noting that every existing `CreatePollTest` fixture passes `maxVotes => 0`, which is exactly why the suite never caught this.

### Reproduce

Create a poll with "allow multiple votes" and a limit of 2 → the stored setting is `max_votes: 0`, and the poll accepts votes for every option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)