### PR TITLE
fix: authorize poll image deletion against the poll, not just the permission

### DIFF
--- a/src/Api/Controllers/DeletePollImageByNameController.php
+++ b/src/Api/Controllers/DeletePollImageByNameController.php
@@ -11,9 +11,12 @@
 
 namespace FoF\Polls\Api\Controllers;
 
+use Flarum\Foundation\ValidationException;
 use Flarum\Http\RequestUtil;
 use FoF\Polls\Events\PollImageDeleting;
+use FoF\Polls\Poll;
 use FoF\Polls\PollImageUploader;
+use FoF\Polls\PollOption;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Laminas\Diactoros\Response\EmptyResponse;
@@ -35,6 +38,26 @@ class DeletePollImageByNameController implements RequestHandlerInterface
         $fileName = Arr::get($request->getQueryParams(), 'fileName');
 
         $actor->assertCan('uploadPollImages');
+
+        // Keep this endpoint to a single, bare filename. Flysystem already
+        // refuses to traverse outside the disk, but rejecting it here makes the
+        // contract explicit and turns a malformed name into a 422 rather than
+        // an unhandled filesystem error.
+        if (!is_string($fileName) || $fileName === '' || basename($fileName) !== $fileName) {
+            throw new ValidationException(['fileName' => 'The file name must be a single path segment.']);
+        }
+
+        // This endpoint exists so the client can clean up an image it just
+        // uploaded for a poll that was never saved. If the name is already
+        // attached to a poll or option, deleting it is an edit of that poll and
+        // needs the same per-poll check the upload endpoint performs — image
+        // filenames are public in poll payloads, so otherwise any user holding
+        // `uploadPollImages` could delete another author's image.
+        if ($poll = Poll::where('image', $fileName)->first()) {
+            $actor->assertCan('edit', $poll);
+        } elseif ($option = PollOption::where('image_url', $fileName)->first()) {
+            $actor->assertCan('edit', $option->poll);
+        }
 
         // Check if the base file exists (any variant implies it was uploaded)
         $basePath = $fileName;

--- a/src/Api/Controllers/DeletePollImageController.php
+++ b/src/Api/Controllers/DeletePollImageController.php
@@ -36,9 +36,14 @@ class DeletePollImageController implements RequestHandlerInterface
         $pollId = Arr::get($request->getQueryParams(), 'pollId');
 
         /** @var Poll $poll */
-        $poll = Poll::find($pollId);
+        $poll = Poll::findOrFail($pollId);
 
         $actor->assertCan('uploadPollImages');
+        // Deleting a poll's image is an edit of that poll, so it needs the same
+        // per-poll check the upload endpoint already performs. Without it, the
+        // `uploadPollImages` permission alone let any user clear the image of
+        // any poll, and poll ids are trivially enumerable.
+        $actor->assertCan('edit', $poll);
 
         $this->events->dispatch(
             new PollImageDeleting($poll->image, $actor)

--- a/src/Api/Controllers/DeletePollOptionImageController.php
+++ b/src/Api/Controllers/DeletePollOptionImageController.php
@@ -36,9 +36,13 @@ class DeletePollOptionImageController implements RequestHandlerInterface
         $optionId = Arr::get($request->getQueryParams(), 'optionId');
 
         /** @var PollOption $option */
-        $option = PollOption::find($optionId);
+        $option = PollOption::findOrFail($optionId);
 
         $actor->assertCan('uploadPollImages');
+        // Same per-poll check the option upload endpoint already performs —
+        // otherwise `uploadPollImages` alone was enough to clear the image of
+        // any option on any poll.
+        $actor->assertCan('edit', $option->poll);
 
         if ($option->image_url) {
             /**

--- a/tests/integration/api/DeletePollImageAuthorizationTest.php
+++ b/tests/integration/api/DeletePollImageAuthorizationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Polls\Tests\integration\api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\Polls\Poll;
+use FoF\Polls\PollOption;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The image delete endpoints only checked the global `uploadPollImages`
+ * permission, never whether the actor may edit the poll the image belongs to —
+ * unlike the upload endpoints, which do. Any user holding `uploadPollImages`
+ * could therefore clear the image of a poll owned by someone else, by id or by
+ * filename (poll ids are sequential and image filenames are public in poll
+ * payloads).
+ */
+class DeletePollImageAuthorizationTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-polls');
+
+        $this->setting('fof-polls.enableGlobalPolls', true);
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'pollowner', 'email' => 'pollowner@machine.local', 'password' => 'too-obscure', 'is_email_confirmed' => true],
+                ['id' => 4, 'username' => 'otheruser', 'email' => 'otheruser@machine.local', 'password' => 'too-obscure', 'is_email_confirmed' => true],
+            ],
+            'polls' => [
+                ['id' => 1, 'question' => 'Owned by user 3', 'post_id' => null, 'user_id' => 3, 'end_date' => null, 'image' => 'pollImage-owned.webp', 'image_alt' => null, 'created_at' => '2021-01-01 00:00:00', 'updated_at' => '2021-01-01 00:00:00', 'vote_count' => 0, 'published_at' => '2021-01-01 00:00:00', 'settings' => '{"max_votes": 0,"hide_votes": false,"public_poll": false,"allow_change_vote": false,"allow_multiple_votes": false}'],
+            ],
+            'poll_options' => [
+                ['id' => 1, 'answer' => 'Option 1', 'poll_id' => 1, 'vote_count' => 0, 'image_url' => 'pollImage-option.webp', 'created_at' => '2021-01-01 00:00:00', 'updated_at' => '2021-01-01 00:00:00'],
+            ],
+            'group_user' => [
+                ['user_id' => 3, 'group_id' => 4],
+                ['user_id' => 4, 'group_id' => 4],
+            ],
+            'group_permission' => [
+                // Both users may upload poll images and edit their *own* polls.
+                // Only user 3 owns the fixture poll, so only user 3 may touch it.
+                ['permission' => 'uploadPollImages', 'group_id' => 4],
+                ['permission' => 'polls.selfEdit', 'group_id' => 4],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function user_cannot_delete_another_users_poll_image_by_id()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollImage/1', ['authenticatedAs' => 4])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals('pollImage-owned.webp', Poll::find(1)->image);
+    }
+
+    #[Test]
+    public function user_cannot_delete_another_users_poll_image_by_name()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollImage/name/pollImage-owned.webp', ['authenticatedAs' => 4])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals('pollImage-owned.webp', Poll::find(1)->image);
+    }
+
+    #[Test]
+    public function user_cannot_delete_another_users_option_image_by_id()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollOptionImage/1', ['authenticatedAs' => 4])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals('pollImage-option.webp', PollOption::find(1)->image_url);
+    }
+
+    #[Test]
+    public function poll_owner_can_still_delete_their_own_poll_image()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollImage/1', ['authenticatedAs' => 3])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(Poll::find(1)->image);
+    }
+
+    #[Test]
+    public function poll_owner_can_still_delete_their_own_option_image()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollOptionImage/1', ['authenticatedAs' => 3])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertNull(PollOption::find(1)->image_url);
+    }
+
+    #[Test]
+    public function deleting_an_unknown_poll_image_is_not_found_rather_than_a_server_error()
+    {
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollImage/999', ['authenticatedAs' => 3])
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function an_unreferenced_filename_can_still_be_cleaned_up()
+    {
+        // The by-name endpoint exists so the client can remove an image it just
+        // uploaded for a poll that was never saved. A name attached to no poll
+        // stays deletable by anyone who may upload images.
+        $response = $this->send(
+            $this->request('DELETE', '/api/polls/pollImage/name/pollImage-orphan.webp', ['authenticatedAs' => 4])
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
### Summary

The three image delete endpoints check only the global `uploadPollImages` permission and never whether the actor may edit the poll the image belongs to. The matching **upload** endpoints already do — `UploadPollImageController` and `UploadPollOptionImageController` both `findOrFail` the poll and `assertCan('edit', $poll)` — so this brings delete in line with upload.

### Impact

Any user granted `uploadPollImages` can clear the image of a poll they don't own:

- **By id** — `DELETE /api/polls/pollImage/{pollId}`, and poll ids are sequential.
- **By filename** — `DELETE /api/polls/pollImage/name/{fileName}`; image filenames are public in poll payloads, so they're simply read off any visible poll.
- **Option images** — same via `DELETE /api/polls/pollOptionImage/{optionId}`.

The change is persisted (`image = null; save()`), and the underlying files plus their @2x/@3x variants are removed.

Not arbitrary file deletion: `fileName` is unvalidated, but Flysystem v3 throws `PathTraversalDetected` on `..`, so it stays within the poll image disk.

### Changes

- `DeletePollImageController` / `DeletePollOptionImageController`: add the per-poll `edit` check. Also switch `find()` → `findOrFail()` — both immediately dereferenced the result (`$poll->image`), so an unknown id was a 500 rather than a 404.
- `DeletePollImageByNameController`: this endpoint exists so the client can clean up an image it just uploaded for a poll that was never saved, so an **unreferenced** filename stays deletable by anyone who may upload. A name already attached to a poll or option now requires `edit` on that poll. The name is also constrained to a single path segment, so a malformed value is a 422 instead of an unhandled filesystem error.

### Tests

New `DeletePollImageAuthorizationTest` covers cross-user deletion by id, by name and for option images, plus the owner happy paths, the unknown-id 404, and the orphan cleanup case that must keep working.

Let me know if you'd rather handle the disclosure differently — it needs an existing granted permission and is destructive rather than a data leak, so I've filed it in the open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)