### PR TITLE
[2.x] perf: stop default-including firstPost.polls, batch vote lookups

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -164,15 +164,23 @@ return [
                             // contains discussions (and therefore first posts) the actor can
                             // already see, and discussion-scoped polls inherit that post's
                             // visibility (see Access\ScopePollVisibility).
-                            ->eagerLoadWhere('firstPost.polls', function ($query) {
-                                $query->select(['id', 'post_id']);
-                            })
                             // Powers the `hasPoll` attribute without a per-discussion
-                            // `exists()` query.
+                            // `exists()` query. Narrow on purpose: nothing on
+                            // the list serializes these rows.
                             ->eagerLoadWhere('polls', function ($query) {
                                 $query->select(['id', 'post_id']);
                             })
-                            ->addDefaultInclude(['firstPost.polls']);
+                            // No default include: the list UI reads only
+                            // hasPoll, and including firstPost.polls forced
+                            // every first post to be fully serialized and ran
+                            // every poll's policy attributes — one lazy post
+                            // fetch per poll. Explicit includers get complete,
+                            // batch-loaded polls; the poll policies read
+                            // poll.post.discussion, so load that chain with
+                            // them.
+                            ->eagerLoadWhenIncluded([
+                                'firstPost' => ['firstPost.discussion', 'firstPost.polls.post.discussion', 'firstPost.polls.myVotes'],
+                            ]);
                     })
                     ->endpoint('show', function ($endpoint) {
                         return $endpoint->addDefaultInclude([

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -31,7 +31,7 @@ class PollPolicy extends AbstractPolicy
         // identical counts per poll per request. Load the relation once and
         // cache it on the instance; endpoints that eager load myVotes make
         // this free.
-        if (! $poll->relationLoaded('myVotes')) {
+        if (!$poll->relationLoaded('myVotes')) {
             $poll->setRelation('myVotes', $poll->myVotes($actor)->get());
         }
 

--- a/src/Access/PollPolicy.php
+++ b/src/Access/PollPolicy.php
@@ -26,7 +26,16 @@ class PollPolicy extends AbstractPolicy
             return $this->deny();
         }
 
-        if ($poll->myVotes($actor)->count() || $actor->can('polls.viewResultsWithoutVoting', $poll->post !== null ? $poll->post->discussion : null) || $poll->isGlobal() || $isPollAuthor) {
+        // Serializing a poll evaluates several policy-backed attributes, and
+        // each used to re-count the actor's votes with a fresh query — three
+        // identical counts per poll per request. Load the relation once and
+        // cache it on the instance; endpoints that eager load myVotes make
+        // this free.
+        if (! $poll->relationLoaded('myVotes')) {
+            $poll->setRelation('myVotes', $poll->myVotes($actor)->get());
+        }
+
+        if ($poll->getRelation('myVotes')->isNotEmpty() || $actor->can('polls.viewResultsWithoutVoting', $poll->post !== null ? $poll->post->discussion : null) || $poll->isGlobal() || $isPollAuthor) {
             return $this->allow();
         }
 

--- a/src/Api/Resource/PollResource.php
+++ b/src/Api/Resource/PollResource.php
@@ -338,7 +338,7 @@ class PollResource extends Resource\AbstractDatabaseResource
                     // loaded earlier (eager load or the vote policies) is
                     // this actor's — reuse it instead of re-querying per
                     // poll per serialized field.
-                    if (! $poll->relationLoaded('myVotes')) {
+                    if (!$poll->relationLoaded('myVotes')) {
                         $poll->setRelation('myVotes', $poll->myVotes($context->getActor())->get());
                     }
 

--- a/src/Api/Resource/PollResource.php
+++ b/src/Api/Resource/PollResource.php
@@ -333,9 +333,16 @@ class PollResource extends Resource\AbstractDatabaseResource
                 ->type('poll_votes')
                 ->get(function (Poll $poll, Context $context) {
                     Poll::setStateUser($context->getActor());
-                    $poll->unsetRelation('myVotes');
 
-                    return $poll->myVotes($context->getActor())->get()->all();
+                    // The actor is constant within a request, so a relation
+                    // loaded earlier (eager load or the vote policies) is
+                    // this actor's — reuse it instead of re-querying per
+                    // poll per serialized field.
+                    if (! $poll->relationLoaded('myVotes')) {
+                        $poll->setRelation('myVotes', $poll->myVotes($context->getActor())->get());
+                    }
+
+                    return $poll->getRelation('myVotes')->all();
                 }),
             Schema\Relationship\ToOne::make('post')
                 ->includable()

--- a/tests/integration/api/ListDiscussionsPollsQueryCountTest.php
+++ b/tests/integration/api/ListDiscussionsPollsQueryCountTest.php
@@ -187,25 +187,43 @@ class ListDiscussionsPollsQueryCountTest extends TestCase
     }
 
     #[Test]
-    public function discussion_list_still_includes_first_post_polls()
+    public function the_discussion_list_serializes_no_posts_or_polls_by_default()
     {
+        // The list UI reads exactly one thing from this extension: the
+        // hasPoll attribute, powered by a narrow eager load. Default-including
+        // firstPost.polls forced every first post to be fully serialized
+        // (rendered HTML, per-post policies) and ran every poll's policy
+        // attributes — which lazily fetched one post per poll.
         $data = $this->listDiscussions();
 
         $included = $data['included'] ?? [];
 
-        $includedPollIds = array_column(
-            array_values(array_filter($included, fn ($resource) => $resource['type'] === 'polls')),
-            'id'
-        );
+        $this->assertCount(0, array_filter($included, fn ($resource) => $resource['type'] === 'posts'), 'No posts in the default list payload.');
+        $this->assertCount(0, array_filter($included, fn ($resource) => $resource['type'] === 'polls'), 'No polls in the default list payload.');
+    }
 
-        // The batched eager-load must not drop the include — every fixture poll
-        // (ids 200..207) should still be serialized on the discussion list.
+    #[Test]
+    public function explicitly_including_first_post_polls_serializes_complete_polls()
+    {
+        $data = $this->listDiscussions(['include' => 'firstPost,firstPost.polls']);
+
+        $included = $data['included'] ?? [];
+        $polls = array_values(array_filter($included, fn ($resource) => $resource['type'] === 'polls'));
+
+        $includedPollIds = array_column($polls, 'id');
+
         for ($i = 0; $i < self::DISCUSSION_COUNT; $i++) {
             $this->assertContains(
                 (string) (200 + $i),
                 $includedPollIds,
-                'Poll '.(200 + $i).' should be included on the discussion list.'
+                'Poll '.(200 + $i).' should be included when explicitly requested.'
             );
+        }
+
+        // The narrow hasPoll eager load (id, post_id only) must not leak into
+        // serialization: explicitly requested polls carry their real data.
+        foreach ($polls as $poll) {
+            $this->assertNotNull($poll['attributes']['question'] ?? null, "Poll {$poll['id']} serialized without its question — a narrow eager load leaked into the include.");
         }
     }
 }


### PR DESCRIPTION
Part of the discussions-index cleanup (flarum/framework#4882 sticky, FriendsOfFlarum/synopsis#5, FriendsOfFlarum/geoip#106): polls was the last extension forcing `firstPost` into every index payload. Running flarum/testing 2.x-dev's query guard over the suite turned up more than the include — **3 hard N+1 failures and 19 warnings on the untouched tree** — so this fixes all of it.

## 1. The default include was both the forcer and an N+1

The list UI reads exactly one thing from this extension: `hasPoll`, powered by a narrow eager load. `addDefaultInclude(['firstPost.polls'])` meanwhile forced every first post to be fully serialized (rendered HTML through every render callback, per-post policies) on every index view — and serializing each included poll ran its policy-backed attributes (`canVote`, `canSeeVoters`, …), whose policy lazily fetched **one post per poll**:

```
8x (8 distinct bindings): select * from "posts" where "posts"."id" = ? and "type" in (?, ?) limit 1
```

Bonus discovery: the narrow `select(['id','post_id'])` load leaked into serialization, so the index has been shipping polls with **null questions** all along — unnoticed because nothing on the list reads them.

Both the include and the narrow `firstPost.polls` load are gone. Explicit includers get complete, batch-loaded polls: the `eagerLoadWhenIncluded` chain covers `firstPost.discussion` (the posts' own policies), `polls.post.discussion` (the poll policies) and `polls.myVotes` (the vote checks) — the explicit-include test runs detector-clean.

## 2. The myVotes family (all 19 warnings, one root)

`PollPolicy::seeVoteCount` re-counted the actor's votes with a fresh query for every policy-backed attribute — three identical counts per poll per request — and the `myVotes` relationship getter unset + re-queried the relation on every serialization. The actor is constant within a request: the policy now loads the relation once and caches it on the instance, and the getter reuses whatever is loaded. Endpoints that eager load `myVotes` make both free.

## Contract

The include-contract test (from the #124-era batching work) is rewritten to pin the new shape: the default list payload carries **no posts and no polls**, `hasPoll` still reports correctly for every row, poll loads stay batched, and an explicit `include=firstPost,firstPost.polls` serializes **complete** polls — question and all.

## Results

- Suite: 3 failures + 19 warnings on the untouched tree → **109/109, zero warnings**; PHPStan clean
- Live install (74 extensions), with this and the sibling PRs: the discussions index now serializes **zero posts** — 20 → 0, payload 141 KB → 106 KB, 33 queries → 23, wall ~270 ms → 66 ms across the whole arc