### PR TITLE
[2.x] fix: allow non-admins to upload a poll image before the poll exists

### DIFF
--- a/src/Api/Controllers/UploadPollImageController.php
+++ b/src/Api/Controllers/UploadPollImageController.php
@@ -13,6 +13,8 @@ namespace FoF\Polls\Api\Controllers;
 
 use Flarum\Http\RequestUtil;
 use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\User\Exception\PermissionDeniedException;
+use Flarum\User\User;
 use FoF\Polls\Events\PollImageWillBeResized;
 use FoF\Polls\Poll;
 use FoF\Polls\PollImageUploader;
@@ -50,8 +52,14 @@ class UploadPollImageController implements RequestHandlerInterface
             $actor->assertCan('edit', $poll);
         } else {
             $poll = null;
-            $actor->assertCan('startPoll');
-            $actor->assertCan('startGlobalPoll');
+
+            // The poll doesn't exist yet (the composer uploads the image
+            // before saving), so there is no model to authorize against —
+            // only "may this actor start a poll at all". `startPoll` cannot
+            // serve here: it is a policy ability on Post, so with no model
+            // core's Gate falls back to hasPermission('startPoll'), which no
+            // group can ever hold. That made this admin-only (issue #131).
+            $this->assertCanStartAnyPoll($actor);
         }
 
         $file = Arr::get($request->getUploadedFiles(), $this->filenamePrefix);
@@ -87,5 +95,20 @@ class UploadPollImageController implements RequestHandlerInterface
             'fileUrl'  => $this->uploader->url($uploadName),
             'fileName' => $uploadName,
         ]);
+    }
+
+    /**
+     * Assert the actor may start a poll somewhere — used when the poll being
+     * illustrated does not exist yet, so there is nothing to authorize
+     * against. Global polls and discussion polls are separate abilities, and
+     * holding either is enough to be legitimately uploading an image.
+     */
+    protected function assertCanStartAnyPoll(User $actor): void
+    {
+        if ($actor->can('startGlobalPoll') || $actor->can('discussion.polls.start')) {
+            return;
+        }
+
+        throw new PermissionDeniedException();
     }
 }

--- a/src/Api/Controllers/UploadPollOptionImageController.php
+++ b/src/Api/Controllers/UploadPollOptionImageController.php
@@ -36,8 +36,10 @@ class UploadPollOptionImageController extends UploadPollImageController
             $actor->assertCan('edit', $poll);
         } else {
             $option = null;
-            $actor->assertCan('startPoll');
-            $actor->assertCan('startGlobalPoll');
+
+            // No option to authorize against yet — see
+            // UploadPollImageController::assertCanStartAnyPoll().
+            $this->assertCanStartAnyPoll($actor);
         }
 
         $file = Arr::get($request->getUploadedFiles(), $this->filenamePrefix);

--- a/tests/integration/api/UploadPollImageAuthorizationTest.php
+++ b/tests/integration/api/UploadPollImageAuthorizationTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of fof/polls.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Polls\Tests\integration\api;
+
+use Flarum\Group\Group;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use Laminas\Diactoros\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Uploading an image for a poll that does not exist yet — the composer flow,
+ * where the image is uploaded before the poll is saved.
+ *
+ * That path used to assert `startPoll` with no model. `startPoll` is a policy
+ * ability on Post, so with a null model core's Gate consults only GLOBAL
+ * policies, finds nothing, and falls back to `hasPermission('startPoll')`.
+ * No group can hold that — it isn't a registered permission — so the check
+ * could only ever pass for admins: non-admins got a 403 when adding an image
+ * to a poll while creating it (issue #131).
+ */
+class UploadPollImageAuthorizationTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    private const UPLOADER_GROUP = 100;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-polls');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(), // id 2, Members — may start discussions + upload
+                ['id' => 3, 'username' => 'nostart', 'email' => 'nostart@machine.local', 'is_email_confirmed' => 1],
+            ],
+            Group::class => [
+                ['id' => self::UPLOADER_GROUP, 'name_singular' => 'Uploader', 'name_plural' => 'Uploaders'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => self::UPLOADER_GROUP],
+                ['user_id' => 3, 'group_id' => self::UPLOADER_GROUP],
+            ],
+            'group_permission' => [
+                // Both users may upload poll images, but only Members (user 2)
+                // may actually start a poll in a discussion.
+                ['group_id' => self::UPLOADER_GROUP, 'permission' => 'uploadPollImages'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'discussion.polls.start'],
+                ['group_id' => Group::MEMBER_ID, 'permission' => 'discussion.startDiscussion'],
+            ],
+        ]);
+    }
+
+    /**
+     * A real 1x1 PNG: the validator decodes the upload with Intervention, so a
+     * dummy byte string won't do.
+     */
+    private function pngUpload(string $field = 'pollImage'): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'poll-image').'.png';
+
+        $image = imagecreatetruecolor(1, 1);
+        imagepng($image, $path);
+        imagedestroy($image);
+
+        return [$field => new UploadedFile($path, filesize($path), UPLOAD_ERR_OK, 'poll.png', 'image/png')];
+    }
+
+    private function upload(string $uri, int $actorId, string $field = 'pollImage'): int
+    {
+        return $this->send(
+            $this->request('POST', $uri, ['authenticatedAs' => $actorId])
+                ->withUploadedFiles($this->pngUpload($field))
+        )->getStatusCode();
+    }
+
+    #[Test]
+    public function a_non_admin_who_may_start_polls_can_upload_an_image_before_the_poll_exists()
+    {
+        // The reported case: user 2 holds uploadPollImages and
+        // discussion.polls.start, and is composing a new discussion with a
+        // poll. There is no poll id yet.
+        $this->assertSame(200, $this->upload('/api/polls/pollImage', 2));
+    }
+
+    #[Test]
+    public function a_non_admin_who_may_start_polls_can_upload_an_option_image_before_the_poll_exists()
+    {
+        $this->assertSame(200, $this->upload('/api/polls/pollOptionImage', 2, 'pollOptionImage'));
+    }
+
+    #[Test]
+    public function an_admin_can_still_upload_before_the_poll_exists()
+    {
+        $this->assertSame(200, $this->upload('/api/polls/pollImage', 1));
+    }
+
+    #[Test]
+    public function a_user_who_cannot_start_a_poll_anywhere_is_refused()
+    {
+        // discussion.polls.start is granted to Members by default, so revoke
+        // it to model an actor who may upload poll images but has no poll they
+        // could legitimately be creating one for.
+        $this->database()->table('group_permission')
+            ->where('permission', 'discussion.polls.start')
+            ->delete();
+
+        $this->assertSame(403, $this->upload('/api/polls/pollImage', 3));
+    }
+}


### PR DESCRIPTION
Fixes #131 — reported by @ekumanov, who also diagnosed the cause.

### The bug

Adding an image to a poll while creating it returned **403 for every non-admin**, no matter which permissions they held. Editing an existing poll's image worked, because that path takes the `if ($pollId)` branch and correctly checks `assertCan('edit', $poll)`.

The composer uploads the image before the poll is saved, so on that path there is no model to authorize against. It asserted:

```php
$actor->assertCan('startPoll');
$actor->assertCan('startGlobalPoll');
```

`startPoll` is a policy ability on `Post` (`Access\PostPolicy::startPoll`). With a null model, core's `Gate::allows()` only consults `GLOBAL` policies — so the Post policy is never evaluated — and falls through to:

```php
return $actor->isAdmin() || $actor->hasPermission($ability);
```

`startPoll` is never registered as a grantable permission (the admin extender registers `startGlobalPoll`, `uploadPollImages` and `startPollGroup`), so `hasPermission('startPoll')` is always false and only the `isAdmin()` branch could ever pass.

The two asserts were also **AND**-ed, so even where the first check passed, a user creating a discussion poll was required to hold `startGlobalPoll` as well.

### The fix

Both controllers now share `assertCanStartAnyPoll()`, which permits the upload when the actor can start a global poll **or** holds `discussion.polls.start` — the grantable permission the `canStartPolls` forum attribute already uses. `uploadPollImages` is still asserted first, so the upload stays behind both "may upload poll images" and "could actually be creating a poll".

On the design question left open in the issue: I kept the poll-start requirement rather than letting `uploadPollImages` stand alone, since the request writes a file to disk and the second check keeps that tied to a plausible poll.

Note that `UploadPollOptionImageController` overrides `handle()` and carried its own copy of the same broken branch, so option images were affected identically.

### Tests

New `UploadPollImageAuthorizationTest` covers the pre-save upload path for both poll and option images, the admin case, and a user who may upload but cannot start a poll anywhere (403).

Proven red first: the two pre-save cases return 403 against the current controllers and 200 with the fix, while the negative and admin cases hold in both directions. Full suite 122/122, PHPStan clean.